### PR TITLE
Replace change_username pubsub prefix with peppy

### DIFF
--- a/app/redis.py
+++ b/app/redis.py
@@ -36,7 +36,7 @@ class UsernameChange(TypedDict):
     userID: str
 
 
-@register_pubsub("less:change_username")
+@register_pubsub("peppy:change_username")
 async def handle_username_change(payload: str) -> None:
     data: UsernameChange = orjson.loads(payload)
     user_id = int(data["userID"])


### PR DESCRIPTION
This was originally `less` as per the original repo's usecase, however we still use `peppy` in many cases and it makes more sense to keep the same behaviour.