### PR TITLE
Fix duplicate scores by replacing score check with an online checksum check

### DIFF
--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -191,17 +191,8 @@ async def submit_score(
     score.time_elapsed = score_time if score.passed else fail_time
 
     if await app.state.services.read_database.fetch_val(
-        (
-            f"SELECT 1 FROM {score.mode.scores_table} WHERE userid = :id AND beatmap_md5 = :md5 AND score = :score "
-            "AND play_mode = :mode AND mods = :mods"
-        ),
-        {
-            "id": user.id,
-            "md5": beatmap.md5,
-            "score": score.score,
-            "mode": score.mode.as_vn,
-            "mods": score.mods.value,
-        },
+        f"SELECT 1 FROM {score.mode.scores_table} WHERE checksum = :checksum",
+        {"checksum": score.checksum},
     ):
         # duplicate score detected
         return b"error: no"
@@ -232,9 +223,9 @@ async def submit_score(
         (
             # TODO: add playtime
             f"INSERT INTO {score.mode.scores_table} (beatmap_md5, userid, score, max_combo, full_combo, mods, 300_count, 100_count, 50_count, katus_count, "
-            "gekis_count, misses_count, time, play_mode, completed, accuracy, pp, patcher) VALUES "
+            "gekis_count, misses_count, time, play_mode, completed, accuracy, pp, patcher, checksum) VALUES "
             "(:beatmap_md5, :userid, :score, :max_combo, :full_combo, :mods, :300_count, :100_count, :50_count, :katus_count, "
-            ":gekis_count, :misses_count, :time, :play_mode, :completed, :accuracy, :pp, :patcher)"
+            ":gekis_count, :misses_count, :time, :play_mode, :completed, :accuracy, :pp, :patcher, :checksum)"
         ),
         score.db_dict,
     )

--- a/app/models/score.py
+++ b/app/models/score.py
@@ -42,6 +42,8 @@ class Score:
     time: int
     time_elapsed: int = 0  # TODO: store this in db
 
+    online_checksum: Optional[str] = None  # optional as checksum was not always stored
+
     rank: int = 0
     old_best: Optional[Score] = None
     using_patcher: bool = False
@@ -79,6 +81,7 @@ class Score:
             "accuracy": self.acc,
             "pp": self.pp,
             "patcher": self.using_patcher,
+            "checksum": self.online_checksum,
             # "playtime": self.time_elapsed,
         }
 
@@ -107,6 +110,7 @@ class Score:
             # time_elapsed=result["playtime"],
             passed=result["completed"] > ScoreStatus.FAILED,
             quit=result["completed"] == ScoreStatus.QUIT,
+            online_checksum=result["checksum"],
         )
 
     @classmethod
@@ -134,4 +138,5 @@ class Score:
             status=ScoreStatus.FAILED,  # set later
             time=int(time.time()),
             time_elapsed=0,  # set later
+            checksum=data[0],
         )


### PR DESCRIPTION
Some duplicate scores were still getting passed for god knows why, using online checksum check should stop duplicates in any scenario.