### PR TITLE
Recalculate first places on user restriction/unrestriction

### DIFF
--- a/app/constants/mode.py
+++ b/app/constants/mode.py
@@ -122,23 +122,32 @@ class Mode(IntEnum):
     def from_offset(cls, score_id: int) -> Mode:
         # IMPORTANT NOTE: this does not return the correct MODE, just the correct vn/rx/ap representation
         if score_id < RELAX_OFFSET:
-            return Mode.STD_RX
+            return cls.STD_RX
         elif score_id >= AP_OFFSET:
-            return Mode.STD_AP
+            return cls.STD_AP
 
-        return Mode.STD
+        return cls.STD
 
     @classmethod
     def from_lb(cls, mode: int, mods: int) -> Mode:
         if mods & Mods.RELAX:
             if mode == 3:
-                return Mode.MANIA
+                return cls.MANIA
 
-            return Mode(mode + 4)
+            return cls(mode + 4)
         elif mods & Mods.AUTOPILOT:
             if mode != 0:
-                return Mode.STD
+                return cls.STD
 
-            return Mode.STD_AP
+            return cls.STD_AP
 
-        return Mode(mode)
+        return cls(mode)
+
+    @classmethod
+    def from_rx_mode(cls, mode: int, relax: int) -> Mode:
+        if relax == 0:
+            return cls(mode)
+        elif relax == 2:
+            return cls.STD_AP
+        else:
+            return cls(mode + 4)

--- a/app/redis.py
+++ b/app/redis.py
@@ -9,11 +9,11 @@ from typing import TypedDict
 
 import orjson
 import redis.asyncio.client
-from app.constants.mode import Mode
-from app.constants.privileges import Privileges
 
 import app.state
 import app.usecases
+from app.constants.mode import Mode
+from app.constants.privileges import Privileges
 
 PUBSUB_HANDLER = Callable[[str], Awaitable[None]]
 

--- a/app/usecases/leaderboards.py
+++ b/app/usecases/leaderboards.py
@@ -95,3 +95,11 @@ async def find_score_rank(
     assert leaderboard_score is not None
 
     return leaderboard_score["score_rank"]
+
+
+async def fetch_first_place(beatmap: Beatmap, mode: Mode) -> LeaderboardScore | None:
+    return await leaderboards_repository.fetch_first_place(
+        beatmap_md5=beatmap.md5,
+        play_mode=mode.as_vn,
+        scores_table=mode.scores_table,
+    )

--- a/app/usecases/score.py
+++ b/app/usecases/score.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
-from typing import Optional, TypedDict
-from app.constants.mode import Mode
+from typing import Optional
+from typing import TypedDict
 
 import app.state
 import app.usecases
 import app.utils
+from app.constants.mode import Mode
 from app.models.achievement import Achievement
 from app.models.beatmap import Beatmap
 from app.models.score import Score


### PR DESCRIPTION
This PR adds functionality to the `peppy:ban` Redis pubsub, where it will proceed to recalculate the first places for all the beatmaps the user has first places on upon restriction, or try to restore their first places upon unrestriction.

Requires testing.