### PR TITLE
Stop pp cap from restricting on non-submitted scores

### DIFF
--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -245,6 +245,7 @@ async def submit_score(
         beatmap.gives_pp
         and score.pp > await app.usecases.pp_cap.get_pp_cap(score.mode, score.mods)
         and not await app.usecases.whitelist.get_whitelisted(user.id, score.mode)
+        and score.passed
     ):
         await restrict_user(
             user,


### PR DESCRIPTION
Originally intentional but turned out to be victim of abuse cases. In the future would like to make it submit a webhook, but for now removing it is the best action.