### PR TITLE
Add a RabbitMQ queue on score submission

### DIFF
--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -264,7 +264,7 @@ async def submit_score(
             visual_settings_b64=visual_settings_b64.decode(),
             updated_beatmap_hash=updated_beatmap_hash,
             storyboard_md5=storyboard_md5,
-            iv_b64=iv_b64,
+            iv_b64=iv_b64.decode(),
             unique_ids=unique_ids,
             score_time=score_time,
             osu_version=osu_version,

--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -240,29 +240,13 @@ async def submit_score(
                 },
             )
 
-        try:
-            decoded = b64decode(visual_settings_b64).decode(errors="ignore")
-
-            if (
-                decoded[8] == "-"
-                and decoded[13] == "-"
-                and decoded[18] == "-"
-                and decoded[23] == "-"
-                and len(decoded) == 36
-            ):
-                score.using_patcher = True
-            else:
-                score.using_patcher = False
-        except Exception:
-            score.using_patcher = False
-
         score.id = await app.state.services.database.execute(
             (
                 # TODO: add playtime
                 f"INSERT INTO {score.mode.scores_table} (beatmap_md5, userid, score, max_combo, full_combo, mods, 300_count, 100_count, 50_count, katus_count, "
-                "gekis_count, misses_count, time, play_mode, completed, accuracy, pp, patcher, checksum) VALUES "
+                "gekis_count, misses_count, time, play_mode, completed, accuracy, pp, checksum) VALUES "
                 "(:beatmap_md5, :userid, :score, :max_combo, :full_combo, :mods, :300_count, :100_count, :50_count, :katus_count, "
-                ":gekis_count, :misses_count, :time, :play_mode, :completed, :accuracy, :pp, :patcher, :checksum)"
+                ":gekis_count, :misses_count, :time, :play_mode, :completed, :accuracy, :pp, :checksum)"
             ),
             score.db_dict,
         )

--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -5,7 +5,7 @@ import dataclasses
 import logging
 import time
 import aio_pika
-from base64 import b64decode
+from base64 import b64decode, b64encode
 from copy import copy
 from datetime import datetime
 from typing import NamedTuple
@@ -258,18 +258,18 @@ async def submit_score(
     replay_data = await replay_file.read()
     submission_request = dataclasses.asdict(
         ScoreSubmissionRequest(
-            score_data=score_data_b64,
+            score_data=score_data_b64.decode(),
             exited_out=exited_out,
             fail_time=fail_time,
-            visual_settings_b64=visual_settings_b64,
+            visual_settings_b64=visual_settings_b64.decode(),
             updated_beatmap_hash=updated_beatmap_hash,
             storyboard_md5=storyboard_md5,
             iv_b64=iv_b64,
             unique_ids=unique_ids,
             score_time=score_time,
             osu_version=osu_version,
-            client_hash_b64=client_hash_b64,
-            replay_data=replay_data,
+            client_hash_b64=client_hash_b64.decode(),
+            replay_data_b64=b64encode(replay_data).decode(),
             score_id=score.id,
         )
     )

--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -4,8 +4,8 @@ import asyncio
 import dataclasses
 import logging
 import time
-import aio_pika
-from base64 import b64decode, b64encode
+from base64 import b64decode
+from base64 import b64encode
 from copy import copy
 from datetime import datetime
 from typing import NamedTuple
@@ -13,16 +13,16 @@ from typing import Optional
 from typing import TypeVar
 from typing import Union
 
+import aio_pika
+import orjson
 from fastapi import File
 from fastapi import Form
 from fastapi import Header
 from fastapi import Request
 from fastapi.datastructures import FormData
-import orjson
 from py3rijndael import Pkcs7Padding
 from py3rijndael import RijndaelCbc
 from starlette.datastructures import UploadFile as StarletteUploadFile
-from app.models.score_submission_request import ScoreSubmissionRequest
 
 import app.state
 import app.usecases
@@ -32,6 +32,7 @@ from app.constants.mode import Mode
 from app.constants.ranked_status import RankedStatus
 from app.constants.score_status import ScoreStatus
 from app.models.score import Score
+from app.models.score_submission_request import ScoreSubmissionRequest
 from app.objects.path import Path
 from app.usecases.user import restrict_user
 
@@ -274,7 +275,7 @@ async def submit_score(
             user_id=user.id,
             mode_vn=score.mode.as_vn,
             relax=score.mode.relax_int,
-        )
+        ),
     )
 
     # send request to rmq

--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -271,6 +271,9 @@ async def submit_score(
             client_hash_b64=client_hash_b64.decode(),
             replay_data_b64=b64encode(replay_data).decode(),
             score_id=score.id,
+            user_id=user.id,
+            mode_vn=score.mode.as_vn,
+            relax=score.mode.relax_int,
         )
     )
 

--- a/app/init_api.py
+++ b/app/init_api.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import logging
 import pprint
+import aio_pika
 
 import aiobotocore.session
 import aiohttp
@@ -51,6 +52,10 @@ def init_events(asgi_app: FastAPI) -> None:
             config.FTP_HOST,
             config.FTP_USER,
             config.FTP_PASS,
+        )
+
+        app.state.services.amqp = await aio_pika.connect_robust(
+            f"amqp://{config.AMQP_USER}:{config.AMQP_PASS}@{config.AMQP_HOST}:{config.AMQP_PORT}/",
         )
 
         await app.state.cache.init_cache()

--- a/app/init_api.py
+++ b/app/init_api.py
@@ -4,8 +4,8 @@ import asyncio
 import contextlib
 import logging
 import pprint
-import aio_pika
 
+import aio_pika
 import aiobotocore.session
 import aiohttp
 import orjson

--- a/app/init_api.py
+++ b/app/init_api.py
@@ -88,6 +88,8 @@ def init_events(asgi_app: FastAPI) -> None:
 
         app.state.services.ftp_client.close()
 
+        await app.state.services.amqp.close()
+
         await ctx_stack.aclose()
 
         logging.info("Server has shutdown!")

--- a/app/models/score.py
+++ b/app/models/score.py
@@ -48,7 +48,6 @@ class Score:
 
     rank: int = 0
     old_best: Optional[Score] = None
-    using_patcher: bool = False
 
     def osu_string(self, username: str, rank: int) -> str:
         if self.mode > Mode.MANIA:
@@ -82,7 +81,6 @@ class Score:
             "completed": self.status.value,
             "accuracy": self.acc,
             "pp": self.pp,
-            "patcher": self.using_patcher,
             "checksum": self.online_checksum,
             # "playtime": self.time_elapsed,
         }

--- a/app/models/score_submission_request.py
+++ b/app/models/score_submission_request.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 

--- a/app/models/score_submission_request.py
+++ b/app/models/score_submission_request.py
@@ -4,16 +4,16 @@ from typing import Optional
 
 @dataclass
 class ScoreSubmissionRequest:
-    score_data: bytes
+    score_data: str
     exited_out: bool
     fail_time: int
-    visual_settings_b64: bytes
+    visual_settings_b64: str
     updated_beatmap_hash: str
     storyboard_md5: Optional[str]
     iv_b64: bytes
     unique_ids: str
     score_time: int
     osu_version: str
-    client_hash_b64: bytes
-    replay_data: bytes
+    client_hash_b64: str
+    replay_data_b64: str
     score_id: int

--- a/app/models/score_submission_request.py
+++ b/app/models/score_submission_request.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ScoreSubmissionRequest:
+    score_data: bytes
+    exited_out: bool
+    fail_time: int
+    visual_settings_b64: bytes
+    updated_beatmap_hash: str
+    storyboard_md5: Optional[str]
+    iv_b64: bytes
+    unique_ids: str
+    score_time: int
+    osu_version: str
+    client_hash_b64: bytes
+    replay_data: bytes
+    score_id: int

--- a/app/models/score_submission_request.py
+++ b/app/models/score_submission_request.py
@@ -17,3 +17,6 @@ class ScoreSubmissionRequest:
     client_hash_b64: str
     replay_data_b64: str
     score_id: int
+    user_id: int
+    mode_vn: int
+    relax: int

--- a/app/models/score_submission_request.py
+++ b/app/models/score_submission_request.py
@@ -10,7 +10,7 @@ class ScoreSubmissionRequest:
     visual_settings_b64: str
     updated_beatmap_hash: str
     storyboard_md5: Optional[str]
-    iv_b64: bytes
+    iv_b64: str
     unique_ids: str
     score_time: int
     osu_version: str

--- a/app/state/services.py
+++ b/app/state/services.py
@@ -10,6 +10,7 @@ import aioredis
 import databases
 from ftpretty import ftpretty
 from sqlalchemy.sql import ClauseElement
+import aio_pika
 
 import config
 
@@ -19,6 +20,8 @@ redis: aioredis.Redis = aioredis.from_url("redis://localhost")
 ftp_client: ftpretty
 
 http: aiohttp.ClientSession
+
+amqp: aio_pika.RobustConnection
 
 
 class Database:

--- a/app/state/services.py
+++ b/app/state/services.py
@@ -5,12 +5,12 @@ from typing import Mapping
 from typing import Optional
 from typing import Protocol
 
+import aio_pika
 import aiohttp
 import aioredis
 import databases
 from ftpretty import ftpretty
 from sqlalchemy.sql import ClauseElement
-import aio_pika
 
 import config
 

--- a/config.py
+++ b/config.py
@@ -49,3 +49,8 @@ FTP_HOST = config("FTP_HOST")
 FTP_PORT = config("FTP_PORT", cast=int)
 FTP_USER = config("FTP_USER")
 FTP_PASS = config("FTP_PASS")
+
+AMQP_HOST = config("AMQP_HOST")
+AMQP_PORT = config("AMQP_PORT", cast=int)
+AMQP_USER = config("AMQP_USER")
+AMQP_PASS = config("AMQP_PASS")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aio-pika
 aiobotocore
 aioftp
 aiohttp[speedups]
@@ -11,4 +12,3 @@ py3rijndael
 python-multipart
 rosu_pp_py
 uvicorn[standard]
-aio-pika

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ py3rijndael
 python-multipart
 rosu_pp_py
 uvicorn[standard]
+aio-pika


### PR DESCRIPTION
This adds a queue to score submission which may be used for multiple purposes - such as extra anticheat flow outside of the score service.

This requires a RabbitMQ instance to be running on the server (and already is, in the case of Akatsuki).