### PR TITLE
fix: remove unused rosu_pp_py dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ ftpretty
 orjson
 py3rijndael
 python-multipart
-rosu_pp_py
 tenacity
 types-aiobotocore[s3]
 uvicorn[standard]


### PR DESCRIPTION
once again breaking docker CI as rosu_pp_py requires a rust install, and we aren't using it so...