### PR TITLE
Stop relying on "ft" fail_time argument in score submission; break up utils

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - log-stats-in-prod
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - log-stats-in-prod
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,4 +7,3 @@ from . import models
 from . import objects
 from . import state
 from . import usecases
-from . import utils

--- a/app/api/leaderboards.py
+++ b/app/api/leaderboards.py
@@ -9,7 +9,6 @@ from fastapi import Query
 
 import app.state
 import app.usecases
-import app.utils
 from app.constants.leaderboard_type import LeaderboardType
 from app.constants.mode import Mode
 from app.constants.mods import Mods

--- a/app/api/replays.py
+++ b/app/api/replays.py
@@ -9,7 +9,6 @@ from fastapi import Response
 
 import app.state
 import app.usecases
-import app.utils
 import config
 from app import job_scheduling
 from app.adapters import amplitude

--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -26,11 +26,11 @@ from starlette.datastructures import UploadFile as StarletteUploadFile
 
 import app.state
 import app.usecases
-import app.utils
 import config
 from app import job_scheduling
 from app.adapters import amplitude
 from app.constants.mode import Mode
+from app.constants.mods import Mods
 from app.constants.ranked_status import RankedStatus
 from app.constants.score_status import ScoreStatus
 from app.models.achievement import Achievement
@@ -215,15 +215,6 @@ async def submit_score(
             score.status = ScoreStatus.QUIT
         else:
             score.status = ScoreStatus.FAILED
-
-        logging.warning(
-            "Score time output",
-            extra={
-                "user_id": score.user_id,
-                "score_time": score_time,
-                "fail_time": fail_time,
-            },
-        )
 
         score.time_elapsed = score_time
 

--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -225,7 +225,7 @@ async def submit_score(
             },
         )
 
-        score.time_elapsed = score_time if score.passed else fail_time
+        score.time_elapsed = score_time
 
         if score.status == ScoreStatus.BEST:
             await app.state.services.database.execute(

--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -216,6 +216,15 @@ async def submit_score(
         else:
             score.status = ScoreStatus.FAILED
 
+        logging.warning(
+            "Score time output",
+            extra={
+                "user_id": score.user_id,
+                "score_time": score_time,
+                "fail_time": fail_time,
+            },
+        )
+
         score.time_elapsed = score_time if score.passed else fail_time
 
         if score.status == ScoreStatus.BEST:

--- a/app/api/screenshots.py
+++ b/app/api/screenshots.py
@@ -13,7 +13,6 @@ from fastapi import Response
 from fastapi import UploadFile
 
 import app.state
-import app.utils
 import config
 from app import job_scheduling
 from app.adapters import amplitude
@@ -64,7 +63,7 @@ async def upload_screenshot(
     user_agent: str = Header(...),
     x_real_ip: str = Header(...),
 ):
-    if not await app.utils.check_online(user.id):
+    if not await app.usecases.user.user_is_online(user.id):
         logging.error(f"{user} tried to upload a screenshot while offline")
         return ERR_RESP
 

--- a/app/usecases/__init__.py
+++ b/app/usecases/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from . import beatmap
+from . import chat
 from . import countries
 from . import discord
 from . import leaderboards

--- a/app/usecases/chat.py
+++ b/app/usecases/chat.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
 from tenacity import retry
+from tenacity import stop_after_attempt
 from tenacity import wait_exponential
-from tenacity.stop import stop_after_attempt
 
-import app.state
+import app.state.services
 import config
 from app.reliability import retry_if_exception_network_related
-
-
-def make_safe(username: str) -> str:
-    return username.rstrip().lower().replace(" ", "_")
 
 
 @retry(
@@ -30,16 +26,3 @@ async def send_message_to_channel(channel: str, message: str) -> None:
         timeout=2,
     )
     response.raise_for_status()
-
-
-async def check_online(user_id: int) -> bool:
-    key = f"bancho:tokens:ids:{user_id}"
-    return await app.state.services.redis.exists(key)
-
-
-def ts_to_utc_ticks(ts: int) -> int:
-    """Converts a UNIX timestamp to a UTC ticks. Equivalent to the reverse of
-    C#'s `DateTime.ToUniversalTime().Ticks`.
-    """
-
-    return int(ts * 1e7) + 0x89F7FF5F7B58000

--- a/app/usecases/score.py
+++ b/app/usecases/score.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import app.state
 import app.usecases
-import app.utils
 from app import job_scheduling
 from app.models.achievement import Achievement
 from app.models.beatmap import Beatmap
@@ -14,6 +13,7 @@ from app.models.score import Score
 from app.models.stats import Stats
 from app.models.user import User
 from app.objects.binary import BinaryWriter
+from app.utils.datetime import timestamp_to_dotnet_ticks
 
 
 def calculate_accuracy(score: Score) -> float:
@@ -124,7 +124,7 @@ async def handle_first_place(
 
     msg = f"[{score.mode.relax_str}] User {user.embed} has submitted a #1 place on {beatmap.embed} +{score.mods!r} ({score.pp:.2f}pp)"
     await job_scheduling.schedule_job(
-        app.utils.send_message_to_channel("#announce", msg),
+        app.usecases.chat.send_message_to_channel("#announce", msg),
     )
 
 
@@ -181,7 +181,7 @@ async def build_full_replay(score: Score) -> Optional[BinaryWriter]:
         .write_u8_le(score.full_combo)
         .write_i32_le(score.mods.value)
         .write_u8_le(0)
-        .write_i64_le(app.utils.ts_to_utc_ticks(score.time))
+        .write_i64_le(timestamp_to_dotnet_ticks(score.time))
         .write_i32_le(len(replay_bytes))
         .write_raw(replay_bytes)
         .write_i64_le(score.id)

--- a/app/usecases/user.py
+++ b/app/usecases/user.py
@@ -16,15 +16,18 @@ import app.usecases.discord
 import app.usecases.password
 import app.usecases.privileges
 import app.usecases.score
-import app.utils
 import config
 from app.constants.mode import Mode
 from app.constants.privileges import Privileges
 from app.models.user import User
 
 
+def make_safe_username(username: str) -> str:
+    return username.rstrip().lower().replace(" ", "_")
+
+
 async def fetch_db(username: str) -> Optional[User]:
-    safe_name = app.utils.make_safe(username)
+    safe_name = make_safe_username(username)
 
     db_user = await app.state.services.database.fetch_one(
         "SELECT * FROM users WHERE username_safe = :safe_name",
@@ -282,3 +285,8 @@ async def handle_pending_username_change(user_id: int) -> None:
     )
 
     await app.state.services.redis.publish("api:change_username", user_id)
+
+
+async def user_is_online(user_id: int) -> bool:
+    key = f"bancho:tokens:ids:{user_id}"
+    return await app.state.services.redis.exists(key)

--- a/app/utils/datetime.py
+++ b/app/utils/datetime.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+def timestamp_to_dotnet_ticks(ts: int) -> int:
+    """Converts a UNIX timestamp to a UTC ticks. Equivalent to the reverse of
+    C#'s `DateTime.ToUniversalTime().Ticks`.
+    """
+
+    return int(ts * 1e7) + 0x89F7FF5F7B58000


### PR DESCRIPTION
- score time cannot be trusted because it counts paused time; this will need more work
- fail time is not a measurement of time elapsed but rather the offset into the map where the player failed. to get time elapsed for failed scores we will need to parse the .osu file, and do:
```py
beatmap_start_time = get_start_offset_of_mapfile(score.beatmap_id) # note there is no guarantee the [0] index hitobject is the lowest offset
time_elapsed = score.fail_time - beatmap.start_time
```