### PR TITLE
Replace usage of `datetime.utcnow` and `datetime.utcfromtimestamp`

### DIFF
--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -8,6 +8,7 @@ from base64 import b64decode
 from base64 import b64encode
 from copy import copy
 from datetime import datetime
+from datetime import timezone
 from typing import NamedTuple
 from typing import Optional
 from typing import TypeVar
@@ -475,12 +476,17 @@ async def submit_score(
 
     achievements_str = "/".join(ach.full_name for ach in new_achievements)
 
+    beatmap_last_update_datetime = datetime.fromtimestamp(
+        beatmap.last_update,
+        tz=timezone.utc,
+    )
+
     submission_charts = [
         f"beatmapId:{beatmap.id}",
         f"beatmapSetId:{beatmap.set_id}",
         f"beatmapPlaycount:{beatmap.plays}",
         f"beatmapPasscount:{beatmap.passes}",
-        f"approvedDate:{datetime.utcfromtimestamp(beatmap.last_update).strftime('%Y-%m-%d %H:%M:%S')}",
+        f"approvedDate:{beatmap_last_update_datetime:%Y-%m-%d %H:%M:%S}",
         "\n",
         "chartId:beatmap",
         f"chartUrl:{beatmap.set_url}",

--- a/app/usecases/user.py
+++ b/app/usecases/user.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from datetime import datetime
+from datetime import timezone
 from typing import Any
 from typing import Awaitable
 from typing import Callable
@@ -164,7 +165,7 @@ async def insert_restrict_log(user: User, detail: str) -> None:
     """
 
     # Prefix the detail with a less autoban.
-    detail = f"[{datetime.utcnow()}] LESS Restrict: " + detail
+    detail = f"[{datetime.now(tz=timezone.utc)}] LESS Restrict: " + detail
 
     await app.state.services.database.execute(
         f"UPDATE users SET notes = CONCAT(IFNULL(notes, ''), :detail) WHERE id = :id",


### PR DESCRIPTION
> [datetime.datetime](https://docs.python.org/3.12/library/datetime.html#datetime.datetime)’s [utcnow()](https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow) and [utcfromtimestamp()](https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcfromtimestamp) are deprecated and will be removed in a future version. Instead, use timezone-aware objects to represent datetimes in UTC: respectively, call [now()](https://docs.python.org/3.12/library/datetime.html#datetime.datetime.now) and [fromtimestamp()](https://docs.python.org/3.12/library/datetime.html#datetime.datetime.fromtimestamp) with the tz parameter set to [datetime.UTC](https://docs.python.org/3.12/library/datetime.html#datetime.UTC). (Contributed by Paul Ganssle in https://github.com/python/cpython/issues/103857.)