### PR TITLE
Fix ranked statuses getting stuck for maps (typically qualified -> ranked)

### DIFF
--- a/app/usecases/beatmap.py
+++ b/app/usecases/beatmap.py
@@ -18,7 +18,6 @@ async def update_beatmap(beatmap: Beatmap) -> Optional[Beatmap]:
     new_beatmap = await id_from_api(beatmap.id, should_save=False)
     if new_beatmap is None:
         # it's now unsubmitted!
-
         await app.state.services.database.execute(
             "DELETE FROM beatmaps WHERE beatmap_md5 = :old_md5",
             {"old_md5": beatmap.md5},
@@ -33,23 +32,25 @@ async def update_beatmap(beatmap: Beatmap) -> Optional[Beatmap]:
             "DELETE FROM beatmaps WHERE beatmap_md5 = :old_md5",
             {"old_md5": beatmap.md5},
         )
-
-        if beatmap.frozen:
-            # if the previous version is status frozen
-            # we should force the old status on the new version
-            new_beatmap.status = beatmap.status
-            new_beatmap.frozen = True
-
-        # update for new shit
-        new_beatmap.last_update = int(time.time())
-
-        await save(new_beatmap)
-        return new_beatmap
     else:
-        beatmap.last_update = int(time.time())
-        await save(beatmap)
+        # the map may have changed in some ways (e.g. ranked status),
+        # but we want to make sure to keep our stats, because the map
+        # is the same from the player's pov (hit objects, ar/od, etc.)
+        new_beatmap.plays = beatmap.plays
+        new_beatmap.passes = beatmap.passes
+        new_beatmap.rating = beatmap.rating
 
-        return beatmap
+    if beatmap.frozen:
+        # if the previous version is status frozen
+        # we should force the old status on the new version
+        new_beatmap.status = beatmap.status
+        new_beatmap.frozen = True
+
+    # update for new shit
+    new_beatmap.last_update = int(time.time())
+
+    await save(new_beatmap)
+    return new_beatmap
 
 
 async def fetch_by_md5(md5: str) -> Optional[Beatmap]:

--- a/app/usecases/beatmap.py
+++ b/app/usecases/beatmap.py
@@ -18,6 +18,7 @@ async def update_beatmap(beatmap: Beatmap) -> Optional[Beatmap]:
     new_beatmap = await id_from_api(beatmap.id, should_save=False)
     if new_beatmap is None:
         # it's now unsubmitted!
+
         await app.state.services.database.execute(
             "DELETE FROM beatmaps WHERE beatmap_md5 = :old_md5",
             {"old_md5": beatmap.md5},

--- a/app/usecases/beatmap.py
+++ b/app/usecases/beatmap.py
@@ -47,7 +47,6 @@ async def update_beatmap(beatmap: Beatmap) -> Optional[Beatmap]:
         new_beatmap.status = beatmap.status
         new_beatmap.frozen = True
 
-    # update for new shit
     new_beatmap.last_update = int(time.time())
 
     await save(new_beatmap)


### PR DESCRIPTION
Reported by BN teams here: https://discord.com/channels/365406575893938177/714659303075741806/1242447861103464449

Replicatable on production using these maps:
- https://osu.ppy.sh/beatmapsets/1669274#taiko/4510357 Only kantan affected
- https://osu.ppy.sh/beatmapsets/2141913#taiko/4532938 Only Inner Oni & Tatsujin affected
- https://osu.ppy.sh/beatmapsets/2149262#taiko/4527707 Only Kantan, Inner Oni and top diff affected
- https://osu.ppy.sh/beatmaps/4507401 Perfect example all the diffs are stuck on qualified