### PR TITLE
Add "rankedby" beatmap column support (including maintaining it on updates)

### DIFF
--- a/app/models/beatmap.py
+++ b/app/models/beatmap.py
@@ -37,7 +37,7 @@ class Beatmap:
     bpm: int
     filename: str
     frozen: bool
-    rankedby: Optional[str]
+    rankedby: Optional[int]
     rating: Optional[float]
 
     @property

--- a/app/models/beatmap.py
+++ b/app/models/beatmap.py
@@ -37,6 +37,7 @@ class Beatmap:
     bpm: int
     filename: str
     frozen: bool
+    rankedby: Optional[str]
     rating: Optional[float]
 
     @property

--- a/app/models/beatmap.py
+++ b/app/models/beatmap.py
@@ -37,6 +37,7 @@ class Beatmap:
     bpm: int = 0
     filename: str = ""
     frozen: bool = False
+    rankedby: Optional[str] = None
     rating: Optional[float] = None
 
     @property
@@ -110,6 +111,7 @@ class Beatmap:
             "bpm": self.bpm,
             "file_name": self.filename,
             "ranked_status_freezed": self.frozen,
+            "rankedby": self.rankedby,
             "rating": self.rating,
         }
 
@@ -132,5 +134,6 @@ class Beatmap:
             bpm=mapping["bpm"],
             filename=mapping["file_name"],
             frozen=mapping["ranked_status_freezed"],
+            rankedby=mapping["rankedby"],
             rating=mapping["rating"],
         )

--- a/app/models/beatmap.py
+++ b/app/models/beatmap.py
@@ -31,14 +31,13 @@ class Beatmap:
 
     hit_length: int
 
-    last_update: int = 0
+    last_update: int
 
-    max_combo: int = 0
-    bpm: int = 0
-    filename: str = ""
-    frozen: bool = False
-    rankedby: Optional[str] = None
-    rating: Optional[float] = None
+    max_combo: int
+    bpm: int
+    filename: str
+    frozen: bool
+    rating: Optional[float]
 
     @property
     def url(self) -> str:

--- a/app/usecases/beatmap.py
+++ b/app/usecases/beatmap.py
@@ -47,6 +47,7 @@ async def update_beatmap(beatmap: Beatmap) -> Optional[Beatmap]:
         # we should force the old status on the new version
         new_beatmap.status = beatmap.status
         new_beatmap.frozen = True
+        new_beatmap.rankedby = beatmap.rankedby
     elif beatmap.status != new_beatmap.status:
         if new_beatmap.status is RankedStatus.PENDING and beatmap.status in {
             RankedStatus.RANKED,

--- a/app/usecases/beatmap.py
+++ b/app/usecases/beatmap.py
@@ -40,6 +40,7 @@ async def update_beatmap(beatmap: Beatmap) -> Optional[Beatmap]:
         new_beatmap.plays = beatmap.plays
         new_beatmap.passes = beatmap.passes
         new_beatmap.rating = beatmap.rating
+        new_beatmap.rankedby = beatmap.rankedby
 
     if beatmap.frozen:
         # if the previous version is status frozen
@@ -147,11 +148,11 @@ async def save(beatmap: Beatmap) -> None:
             REPLACE INTO beatmaps (
                 beatmap_id, beatmapset_id, beatmap_md5, song_name, ar, od, mode,
                 rating, max_combo, hit_length, bpm, playcount, passcount, ranked,
-                latest_update, ranked_status_freezed, file_name
+                latest_update, ranked_status_freezed, file_name, rankedby
             ) VALUES (
                 :beatmap_id, :beatmapset_id, :beatmap_md5, :song_name, :ar, :od, :mode,
                 :rating, :max_combo, :hit_length, :bpm, :playcount, :passcount, :ranked,
-                :latest_update, :ranked_status_freezed, :file_name
+                :latest_update, :ranked_status_freezed, :file_name, :rankedby
             )
             """
         ),
@@ -173,6 +174,7 @@ async def save(beatmap: Beatmap) -> None:
             "latest_update": beatmap.last_update,
             "ranked_status_freezed": beatmap.frozen,
             "file_name": beatmap.filename,
+            "rankedby": beatmap.rankedby,
         },
     )
 
@@ -327,6 +329,7 @@ def parse_from_osu_api(response_json_list: list[dict]) -> list[Beatmap]:
                 bpm=bpm,
                 filename=filename,
                 frozen=frozen,
+                rankedby=None,
                 rating=10.0,
             ),
         )


### PR DESCRIPTION
This column is set when people use the `!map` command in-game -- realized it's unsupported and is getting reset to `NULL` here.