### PR TITLE
Ignore warnings from `multipart.multipart` logger to fix mass log spam

### DIFF
--- a/logging.yaml
+++ b/logging.yaml
@@ -9,6 +9,10 @@ loggers:
     level: WARNING
     handlers: [console]
     propagate: no
+  multipart.multipart:
+    level: ERROR
+    handlers: [console]
+    propagate: no
 handlers:
   console:
     class: logging.StreamHandler


### PR DESCRIPTION
Invalid client HTTP multipart data can cause python-multipart to log _every single byte_ as individual logs:

![image](https://i.cmyui.xyz/F13faEHaITTgB4w.png)

This can cause _massive_ spikes in logged lines:
![image](https://i.cmyui.xyz/vkED-le8Tkby9LsIlgA.png)

I've known some custom clients to make manual changes to multipart data, causing this