### PR TITLE
Add object counts

### DIFF
--- a/app/adapters/amplitude.py
+++ b/app/adapters/amplitude.py
@@ -93,6 +93,14 @@ def format_beatmap(beatmap: Beatmap) -> dict[str, Any]:
         "file_name": beatmap.filename,
         "frozen": beatmap.frozen,
         "rating": beatmap.rating,
+        "bancho_ranked_status": (
+            beatmap.bancho_ranked_status.name
+            if beatmap.bancho_ranked_status is not None
+            else None
+        ),
+        "count_circles": beatmap.count_circles,
+        "count_sliders": beatmap.count_sliders,
+        "count_spinners": beatmap.count_spinners,
     }
 
 

--- a/app/models/beatmap.py
+++ b/app/models/beatmap.py
@@ -41,6 +41,11 @@ class Beatmap:
 
     bancho_ranked_status: RankedStatus | None
 
+    # TODO: remove `None`s once nulls are backfilled
+    count_circles: int | None
+    count_sliders: int | None
+    count_spinners: int | None
+
     @property
     def url(self) -> str:
         server_url = config.SRV_URL.replace("https://", "").replace("http://", "")
@@ -143,4 +148,7 @@ class Beatmap:
                 if mapping["bancho_ranked_status"] is not None
                 else None
             ),
+            count_circles=mapping["count_circles"],
+            count_sliders=mapping["count_sliders"],
+            count_spinners=mapping["count_spinners"],
         )

--- a/app/usecases/beatmap.py
+++ b/app/usecases/beatmap.py
@@ -136,12 +136,12 @@ async def save(beatmap: Beatmap) -> None:
                 beatmap_id, beatmapset_id, beatmap_md5, song_name, ar, od, mode,
                 rating, max_combo, hit_length, bpm, playcount, passcount, ranked,
                 latest_update, ranked_status_freezed, file_name, rankedby,
-                bancho_ranked_status
+                bancho_ranked_status, count_circles, count_sliders, count_spinners
             ) VALUES (
                 :beatmap_id, :beatmapset_id, :beatmap_md5, :song_name, :ar, :od, :mode,
                 :rating, :max_combo, :hit_length, :bpm, :playcount, :passcount, :ranked,
                 :latest_update, :ranked_status_freezed, :file_name, :rankedby,
-                :bancho_ranked_status
+                :bancho_ranked_status, :count_circles, :count_sliders, :count_spinners
             )
             """
         ),
@@ -169,6 +169,9 @@ async def save(beatmap: Beatmap) -> None:
                 if beatmap.bancho_ranked_status is not None
                 else None
             ),
+            "count_circles": beatmap.count_circles,
+            "count_sliders": beatmap.count_sliders,
+            "count_spinners": beatmap.count_spinners,
         },
     )
 
@@ -321,6 +324,10 @@ def parse_from_osu_api(response_json_list: list[dict[str, Any]]) -> list[Beatmap
         od = float(response_json["diff_overall"])
         ar = float(response_json["diff_approach"])
 
+        count_circles = int(response_json["count_circles"])
+        count_sliders = int(response_json["count_sliders"])
+        count_spinners = int(response_json["count_spinners"])
+
         maps.append(
             Beatmap(
                 md5=md5,
@@ -342,6 +349,9 @@ def parse_from_osu_api(response_json_list: list[dict[str, Any]]) -> list[Beatmap
                 rankedby=None,
                 rating=10.0,
                 bancho_ranked_status=bancho_ranked_status,
+                count_circles=count_circles,
+                count_sliders=count_sliders,
+                count_spinners=count_spinners,
             ),
         )
 


### PR DESCRIPTION
Already ran:
```sql
alter table beatmaps add column count_circles int unsigned null default null;
alter table beatmaps add column count_spinners int unsigned null default null;
alter table beatmaps add column count_sliders int unsigned null default null;
```

Backfill script: https://github.com/osuAkatsuki/data-analysis/blob/main/backfills/beatmap_backfills/null_object_counts.py

To be run after backfill is complete:
```sql
alter table beatmaps modify column count_circles int unsigned not null;
alter table beatmaps modify column count_spinners int unsigned not null;
alter table beatmaps modify column count_sliders int unsigned null not null;
```