### PR TITLE
Fix header encoding err while fetching replays with unicode song name

### DIFF
--- a/app/api/replays.py
+++ b/app/api/replays.py
@@ -84,7 +84,7 @@ async def get_full_replay(score_id: int = Path(...)) -> Response:
     if username is None:
         return Response(b"User not found!")
 
-    filename = f"osu-akatsuki-replay-{score_id}.osr"
+    filename = f"replay-osu_{beatmap.id}_{score_id}.osr"
 
     logging.info(f"Serving compiled replay ID {score_id}")
     return Response(

--- a/app/api/replays.py
+++ b/app/api/replays.py
@@ -93,7 +93,8 @@ async def get_full_replay(score_id: int = Path(...)) -> Response:
     if username is None:
         return Response(b"User not found!")
 
-    filename = f"replay-{get_replay_mode_name(score.mode)}_{beatmap.id}_{score_id}.osr"
+    game_mode_str = get_replay_mode_name(score.mode.as_vn)
+    filename = f"replay-{game_mode_str}_{beatmap.id}_{score_id}.osr"
 
     logging.info(f"Serving compiled replay ID {score_id}")
     return Response(

--- a/app/api/replays.py
+++ b/app/api/replays.py
@@ -96,7 +96,6 @@ async def get_full_replay(score_id: int = Path(...)) -> Response:
     game_mode_str = get_replay_mode_name(score.mode.as_vn)
     filename = f"replay-{game_mode_str}_{beatmap.id}_{score_id}.osr"
 
-    logging.info(f"Serving compiled replay ID {score_id}")
     return Response(
         content=bytes(replay.buffer),
         media_type="application/octet-stream",

--- a/app/api/replays.py
+++ b/app/api/replays.py
@@ -84,7 +84,15 @@ async def get_full_replay(score_id: int = Path(...)) -> Response:
     if username is None:
         return Response(b"User not found!")
 
-    filename = f"replay-osu_{beatmap.id}_{score_id}.osr"
+    def get_replay_mode_name(mode: int) -> str:
+        return {
+            0: "osu",
+            1: "taiko",
+            2: "fruits",
+            3: "mania",
+        }[mode]
+
+    filename = f"replay-{get_replay_mode_name(score.mode)}_{beatmap.id}_{score_id}.osr"
 
     logging.info(f"Serving compiled replay ID {score_id}")
     return Response(

--- a/app/api/replays.py
+++ b/app/api/replays.py
@@ -84,7 +84,7 @@ async def get_full_replay(score_id: int = Path(...)) -> Response:
     if username is None:
         return Response(b"User not found!")
 
-    filename = f"{username} - {beatmap.song_name} ({score_id}).osr"
+    filename = f"osu-akatsuki-replay-{score_id}.osr"
 
     logging.info(f"Serving compiled replay ID {score_id}")
     return Response(

--- a/app/api/replays.py
+++ b/app/api/replays.py
@@ -60,6 +60,15 @@ async def get_replay(
     return Response(content=replay_bytes)
 
 
+def get_replay_mode_name(mode: int) -> str:
+    return {
+        0: "osu",
+        1: "taiko",
+        2: "fruits",
+        3: "mania",
+    }[mode]
+
+
 async def get_full_replay(score_id: int = Path(...)) -> Response:
     mode_rep = Mode.from_offset(score_id)
 
@@ -83,14 +92,6 @@ async def get_full_replay(score_id: int = Path(...)) -> Response:
     username = await app.usecases.usernames.get_username(score.user_id)
     if username is None:
         return Response(b"User not found!")
-
-    def get_replay_mode_name(mode: int) -> str:
-        return {
-            0: "osu",
-            1: "taiko",
-            2: "fruits",
-            3: "mania",
-        }[mode]
 
     filename = f"replay-{get_replay_mode_name(score.mode)}_{beatmap.id}_{score_id}.osr"
 


### PR DESCRIPTION
Should fix these: https://app.datadoghq.com/logs?query=service%3Ascore-service%20%22Exception%20in%20ASGI%20application%22%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZBxOtHemWcYtwAAAAAAAAAYAAAAAEFaQnhPdFZwQUFBRDJFN2RQM2VsWlFBVAAAACQAAAAAMDE5MDcxM2ItMmE5OS00ODg0LTllODktNmJiYmNkOGI3Y2I5&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1719282791351&to_ts=1719887591351&live=true