### PR TITLE
Improve resiliency of performance calculation requests

### DIFF
--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -231,15 +231,21 @@ async def submit_score(
         if score_exists:
             return Response(b"error: no")
 
-        score.pp, score.sr = await app.usecases.performance.calculate_performance(
-            beatmap_id=beatmap.id,
-            beatmap_md5=beatmap.md5,
-            mode=score.mode,
-            mods=score.mods.value,
-            max_combo=score.max_combo,
-            accuracy=score.acc,
-            miss_count=score.nmiss,
-        )
+        try:
+            score.pp, score.sr = await app.usecases.performance.calculate_performance(
+                beatmap_id=beatmap.id,
+                beatmap_md5=beatmap.md5,
+                mode=score.mode,
+                mods=score.mods.value,
+                max_combo=score.max_combo,
+                accuracy=score.acc,
+                miss_count=score.nmiss,
+            )
+        except Exception:
+            logging.exception(
+                "Failed to calculate performance for score",
+                extra={"score_id": score.id},
+            )
 
         # calculate the score's status
         if score.passed:


### PR DESCRIPTION
Server has had some instability recently and made me realise that this isn't even really trying to be resilient.. I've added tenacity retry logic onto the performance usecases and opted to use `raise_for_status` instead of returning zeros on a failure - this seemed like odd and unintuitive behavior to me, even with the logging