### PR TITLE
Fix whitelist to distinguish relax and autopilot modes

### DIFF
--- a/app/usecases/whitelist.py
+++ b/app/usecases/whitelist.py
@@ -6,13 +6,13 @@ from app.constants.mode import Mode
 # 0 = none
 # 1 = vanilla
 # 2 = relax
-# 2 = autopilot
-# 3 = all
+# 4 = autopilot
+# 7 = all
 
 
 def _match_verified(whitelist_int: int, mode: Mode) -> bool:
     if mode.autopilot:
-        return whitelist_int & 2 != 0  # TODO: make this 4 to separate from rx
+        return whitelist_int & 4 != 0
     elif mode.relax:
         return whitelist_int & 2 != 0
     else:


### PR DESCRIPTION
## Summary
- Fix autopilot whitelist to use bit 4 instead of bit 2 (which conflicts with relax)
- Update "all" value documentation from 3 to 7 (1+2+4)

Previously, users whitelisted for relax would also bypass autopilot PP caps, and vice versa, because both modes checked the same bit.

## Migration Required
Users with `whitelist=3` (all) need to be updated to `whitelist=7` to include autopilot after this change:
```sql
UPDATE users SET whitelist = 7 WHERE whitelist = 3;
```

## Test plan
- [ ] Verify relax-whitelisted users can still submit scores with PP > cap on relax
- [ ] Verify relax-whitelisted users are NOT whitelisted for autopilot
- [ ] Verify autopilot-whitelisted users (whitelist & 4) can submit scores with PP > cap on autopilot
- [ ] Run migration query for existing "all" whitelist users

🤖 Generated with [Claude Code](https://claude.com/claude-code)