### PR TITLE
Use atomic upsert for first place handling

### DIFF
--- a/app/usecases/score.py
+++ b/app/usecases/score.py
@@ -44,15 +44,11 @@ async def handle_first_place(
     user: User,
 ) -> None:
     await app.state.services.database.execute(
-        "DELETE FROM scores_first WHERE beatmap_md5 = :md5 AND mode = :mode AND rx = :rx",
-        {"md5": score.map_md5, "mode": score.mode.as_vn, "rx": score.mode.relax_int},
-    )
-
-    await app.state.services.database.execute(
-        (
-            "INSERT INTO scores_first (beatmap_md5, mode, rx, scoreid, userid) VALUES "
-            "(:md5, :mode, :rx, :sid, :uid)"
-        ),
+        """\
+        INSERT INTO scores_first (beatmap_md5, mode, rx, scoreid, userid)
+        VALUES (:md5, :mode, :rx, :sid, :uid)
+        ON DUPLICATE KEY UPDATE scoreid = :sid, userid = :uid
+        """,
         {
             "md5": score.map_md5,
             "mode": score.mode.as_vn,


### PR DESCRIPTION
## Summary
- Replace separate DELETE + INSERT with INSERT ON DUPLICATE KEY UPDATE
- Ensures atomicity when updating first place records

Previously, the first place handling deleted the existing entry before inserting the new one. If the INSERT failed after DELETE succeeded, there would be no first place record for that beatmap/mode/rx combination until another score was submitted.

## Test plan
- [ ] Verify first place records are created correctly for new beatmap/mode combinations
- [ ] Verify first place records are updated correctly when a new #1 is submitted
- [ ] Verify the announcement message still fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)