### PR TITLE
Fix mode_str tuple IndexError for Mode.STD_AP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# score-service CLAUDE.md
+
+This file provides guidance to Claude Code specific to the score-service repository.
+
+## Git Repository Guidelines
+
+**CRITICAL: score-service is a fork from RealistikOsu/USSR. Always PR to the correct repository:**
+
+- **❌ NEVER:** Create PRs to `RealistikOsu/USSR` (upstream fork source)
+- **✅ ALWAYS:** Create PRs to `osuAkatsuki/score-service` (our repository)
+- **✅ DO:** Use `gh pr create -R osuAkatsuki/score-service` to ensure correct target repository
+- Verify git remote configuration before creating PRs (origin should be osuAkatsuki)
+
+**Correct PR creation:**
+```bash
+# Always specify the repository explicitly
+gh pr create -R osuAkatsuki/score-service --title "..." --body "..."
+
+# NOT just "gh pr create" which may default to upstream
+```
+
+**Git Remote Configuration:**
+```
+origin   git@github.com:osuAkatsuki/score-service.git (our repo - PR here)
+upstream git@github.com:RealistikOsu/USSR.git (fork source - NEVER PR here)
+```
+
+## Development Workflow
+
+1. Create feature branch from `master`
+2. Make changes
+3. Run linters: `pre-commit run --all-files`
+4. Run type checking: `mypy .`
+5. Commit changes
+6. Push to origin: `git push -u origin <branch>`
+7. Create PR to osuAkatsuki/score-service: `gh pr create -R osuAkatsuki/score-service`
+
+## Code Style
+
+- Python 3.11+
+- Type hints required (mypy strict mode)
+- Black formatter (line length 88)
+- Import sorting with reorder_python_imports
+- Trailing commas enforced
+- Use pre-commit hooks for automatic formatting
+
+## Testing
+
+```bash
+# Run all tests
+pytest
+
+# Run specific test file
+pytest tests/test_achievements.py
+
+# Run with coverage
+pytest --cov=app --cov-report=html
+```
+
+## Achievement System
+
+See `.github/plans/ACHIEVEMENTS_ANALYSIS.md` in the monorepo root for the comprehensive achievement system overhaul plan.
+
+**Key Files:**
+- `app/usecases/user.py` - Achievement unlock logic
+- `app/constants/mode.py` - Game mode definitions
+- `app/state/cache.py` - Achievement condition loading
+- Future: `app/achievements/` - Decorator-based achievement system (planned)

--- a/app/constants/mode.py
+++ b/app/constants/mode.py
@@ -14,6 +14,7 @@ mode_str = (
     "std!rx",
     "taiko!rx",
     "catch!rx",
+    None,  # Index 7: historical autopilot mode (unused since April 21, 2024)
     "std!ap",
 )
 


### PR DESCRIPTION
## Summary

Fixes an IndexError that occurs when `repr(Mode.STD_AP)` is called. This manifests as crashes when autopilot mode appears in logs or string representations.

## Problem

`Mode.STD_AP` has value 8, but the `mode_str` tuple only had 8 entries (indices 0-7), causing:
```python
>>> repr(Mode.STD_AP)
IndexError: tuple index out of range
```

## Root Cause

On April 21, 2024 (commit 216168f), autopilot was refactored from mode 7 to mode 8, but `mode_str` was not updated to account for the gap at index 7.

## Solution

- Add `None` at index 7 (historical autopilot mode, unused since refactor)
- Move `"std!ap"` to index 8 to match `Mode.STD_AP = 8`

## Changes

```python
mode_str = (
    "osu!std",
    "osu!taiko",
    "osu!catch",
    "osu!mania",
    "std!rx",
    "taiko!rx",
    "catch!rx",
    None,  # Index 7: historical autopilot mode (unused since April 21, 2024)
    "std!ap",
)
```

## Testing

```python
>>> repr(Mode.STD_AP)
'std!ap'  # No longer crashes
```

## Impact

Prevents service crashes when autopilot scores are logged or printed.

## Related

Part of Sprint 1 for achievement system overhaul. See `.github/plans/ACHIEVEMENTS_ANALYSIS.md` for full plan.