### PR TITLE
Merge achievement logging and amplitude loops

### DIFF
--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -585,7 +585,6 @@ async def submit_score(
             stats,
         )
 
-        # log achievement unlocks
         for achievement in new_achievements:
             logging.info(
                 f"Achievement unlocked: {achievement.name}",
@@ -598,8 +597,7 @@ async def submit_score(
                 },
             )
 
-        # fire amplitude events for each
-        for achievement in new_achievements:
+            # fire amplitude events for each
             if config.AMPLITUDE_API_KEY:
                 job_scheduling.schedule_job(
                     amplitude.track(


### PR DESCRIPTION
## Summary

Merges the two separate loops over `new_achievements` into a single loop for better performance.

## Changes

**Before:**
```python
for achievement in new_achievements:
    logging.info(...)

for achievement in new_achievements:
    if config.AMPLITUDE_API_KEY:
        amplitude.track(...)
```

**After:**
```python
for achievement in new_achievements:
    logging.info(...)
    
    # fire amplitude events for each
    if config.AMPLITUDE_API_KEY:
        amplitude.track(...)
```

## Impact

- Reduces iteration overhead when achievements are unlocked
- No functional changes
- Comment moved inside loop as requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)