### PR TITLE
Add comprehensive mod conflict and mode-specific validation

### DIFF
--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -221,6 +221,14 @@ async def submit_score(
             "(score submit gate)",
         )
 
+    if score.mods.incompatible_with_mode(score.mode.as_vn):
+        await app.usecases.user.restrict_user(
+            user,
+            "The user attempted to submit a score with the mod combination "
+            f"+{score.mods!r} on {score.mode!r}, which contains mode-incompatible mods. "
+            "(score submit gate)",
+        )
+
     async with RedisLock(f"score_submission:{score.online_checksum}"):
         score_exists = (
             await app.state.services.database.fetch_val(


### PR DESCRIPTION
## Summary

This PR implements comprehensive validation for mod combinations and mode-specific mods to prevent invalid score submissions.

## Changes

### Mod Conflict Validation

Added detection for all invalid mod combinations:
- **NF/RX/AP + SD** - Can't both prevent and require fail
- **NF/RX/AP + PF** - Can't both allow failure and require perfection  
- **RX/AP + NF** - NF is redundant with RX/AP
- **PF + SD** - Redundant/conflicting fail conditions
- **SO + RX/AP** - SpunOut conflicts with auto-aim mods
- Existing checks: DT+HT, EZ+HR, RX+AP, HD+FI, multiple keymods

### Mode-Specific Validation

Added `incompatible_with_mode()` method to check mode restrictions:
- **SpunOut (SO)** and **Autopilot (AP)** - Standard mode only
- **FadeIn (FI)**, **Random (RN)**, **Key mods** - Mania mode only

### Score Submission

Updated score submission endpoint to validate both:
1. Mod conflicts via existing `.conflict` check
2. Mode compatibility via new `.incompatible_with_mode()` check

Users will be auto-restricted if they attempt to submit invalid combinations.

## Context

During achievement backfill analysis, we discovered 1,544 relax scores and 36 autopilot scores with the NF (NoFail) mod bit set, which is semantically meaningless since RX/AP already prevent failure. This validation prevents such submissions in the future.

## Testing

All validation logic was tested with 37 test cases covering:
- 9 fail-prevention conflict scenarios
- 2 SpunOut conflict scenarios
- Existing conflict checks (DT+HT, EZ+HR, etc.)
- Mode-specific restrictions (SO/AP/FI/keymods)
- Valid combinations (no false positives)

All tests passed ✓