### PR TITLE
kill assert control flow, typed score payload, collapse chains, extract status

### DIFF
--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -260,26 +260,7 @@ async def submit_score(
             miss_count=score.nmiss,
         )
 
-        # calculate the score's status
-        if score.passed:
-            if previous_best is not None:
-                if score.pp > previous_best["pp"]:
-                    score.status = ScoreStatus.BEST
-                elif (
-                    score.pp == previous_best["pp"]
-                    and score.score > previous_best["score"]
-                ):
-                    # spin to win!
-                    score.status = ScoreStatus.BEST
-                else:
-                    score.status = ScoreStatus.SUBMITTED
-            else:
-                score.status = ScoreStatus.BEST
-        elif score.quit:
-            score.status = ScoreStatus.QUIT
-        else:
-            score.status = ScoreStatus.FAILED
-
+        score.status = app.usecases.score.calculate_status(score, previous_best)
         score.time_elapsed = score_time
 
         if score.status == ScoreStatus.BEST:

--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -162,10 +162,11 @@ async def submit_score(
 
     try:
         decrypted = DecryptedScoreData.from_tokens(score_tokens)
-    except (ValueError, ValidationError) as exc:
+    except (ValueError, ValidationError):
         logging.warning(
             "Invalid decrypted score data",
-            extra={"error": str(exc)},
+            extra={"score_tokens": score_tokens},
+            exc_info=True,
         )
         return Response(b"error: no")
 

--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -420,22 +420,7 @@ async def submit_score(
                 n50=score.n50,
                 nmiss=score.nmiss,
             )
-            if grade == "XH":
-                stats.xh_count += 1
-            elif grade == "X":
-                stats.x_count += 1
-            elif grade == "SH":
-                stats.sh_count += 1
-            elif grade == "S":
-                stats.s_count += 1
-            elif grade == "A":
-                stats.a_count += 1
-            elif grade == "B":
-                stats.b_count += 1
-            elif grade == "C":
-                stats.c_count += 1
-            elif grade == "D":
-                stats.d_count += 1
+            app.usecases.stats.adjust_grade_counter(stats, grade, +1)
 
             stats.ranked_score += score.score
 
@@ -450,22 +435,11 @@ async def submit_score(
                     n50=previous_best["count_50"],
                     nmiss=previous_best["count_miss"],
                 )
-                if previous_best_grade == "XH":
-                    stats.xh_count -= 1
-                elif previous_best_grade == "X":
-                    stats.x_count -= 1
-                elif previous_best_grade == "SH":
-                    stats.sh_count -= 1
-                elif previous_best_grade == "S":
-                    stats.s_count -= 1
-                elif previous_best_grade == "A":
-                    stats.a_count -= 1
-                elif previous_best_grade == "B":
-                    stats.b_count -= 1
-                elif previous_best_grade == "C":
-                    stats.c_count -= 1
-                elif previous_best_grade == "D":
-                    stats.d_count -= 1
+                app.usecases.stats.adjust_grade_counter(
+                    stats,
+                    previous_best_grade,
+                    -1,
+                )
 
     await app.usecases.stats.save(stats)
 

--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -21,6 +21,7 @@ from fastapi import Response
 from fastapi.datastructures import FormData
 from py3rijndael import Pkcs7Padding
 from py3rijndael import RijndaelCbc
+from pydantic import ValidationError
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
 import app.repositories.leaderboards
@@ -34,6 +35,7 @@ from app.constants.ranked_status import RankedStatus
 from app.constants.score_status import ScoreStatus
 from app.models.achievement import Achievement
 from app.models.beatmap import Beatmap
+from app.models.decrypted_score_data import DecryptedScoreData
 from app.models.score import Score
 from app.models.score_submission_request import ScoreSubmissionRequest
 from app.redis_lock import RedisLock
@@ -151,22 +153,35 @@ async def submit_score(
         return Response(b"error: no")
 
     score_data_b64, replay_file = score_params
-    score_data, _ = decrypt_score_data(
+    score_tokens, _ = decrypt_score_data(
         score_data_b64,
         client_hash_b64,
         iv_b64,
         osu_version,
     )
 
-    beatmap_md5 = score_data[0]
-    if not (beatmap := await app.usecases.akatsuki_beatmaps.fetch_by_md5(beatmap_md5)):
+    try:
+        decrypted = DecryptedScoreData.from_tokens(score_tokens)
+    except (ValueError, ValidationError) as exc:
+        logging.warning(
+            "Invalid decrypted score data",
+            extra={"error": str(exc)},
+        )
+        return Response(b"error: no")
+
+    if not (
+        beatmap := await app.usecases.akatsuki_beatmaps.fetch_by_md5(
+            decrypted.beatmap_md5,
+        )
+    ):
         return Response(b"error: beatmap")
 
-    username = score_data[1].rstrip()
-    if not (user := await app.usecases.user.auth_user(username, password_md5)):
+    if not (
+        user := await app.usecases.user.auth_user(decrypted.username, password_md5)
+    ):
         return Response(b"")  # empty resp tells osu to retry
 
-    score = Score.from_submission(score_data[2:], beatmap_md5, user)
+    score = Score.from_decrypted(decrypted, user)
     previous_best = await app.usecases.leaderboards.fetch_personal_best(
         beatmap,
         score.mode,

--- a/app/api/score_sub.py
+++ b/app/api/score_sub.py
@@ -49,22 +49,27 @@ class ScoreData(NamedTuple):
 
 
 async def parse_form(score_data: FormData) -> ScoreData | None:
-    try:
-        score_parts = score_data.getlist("score")
-        assert len(score_parts) == 2, "Invalid score data"
-
-        score_data_b64 = score_data.getlist("score")[0]
-        assert isinstance(score_data_b64, str), "Invalid score data"
-        replay_file = score_data.getlist("score")[1]
-        assert isinstance(replay_file, StarletteUploadFile), "Invalid replay data"
-    except AssertionError as exc:
-        logging.warning(f"Failed to validate score multipart data: ({exc.args[0]})")
-        return None
-    else:
-        return ScoreData(
-            score_data_b64.encode(),
-            replay_file,
+    score_parts = score_data.getlist("score")
+    if len(score_parts) != 2:
+        logging.warning(
+            "Failed to validate score multipart data: expected 2 score parts",
+            extra={"num_parts": len(score_parts)},
         )
+        return None
+
+    score_data_b64, replay_file = score_parts
+    if not isinstance(score_data_b64, str):
+        logging.warning(
+            "Failed to validate score multipart data: score payload is not a string",
+        )
+        return None
+    if not isinstance(replay_file, StarletteUploadFile):
+        logging.warning(
+            "Failed to validate score multipart data: replay is not an upload file",
+        )
+        return None
+
+    return ScoreData(score_data_b64.encode(), replay_file)
 
 
 class ScoreClientData(NamedTuple):

--- a/app/models/decrypted_score_data.py
+++ b/app/models/decrypted_score_data.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Annotated
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic import BeforeValidator
+from pydantic import ConfigDict
+
+
+def _parse_bool_str(value: Any) -> bool:
+    if isinstance(value, str):
+        if value == "True":
+            return True
+        if value == "False":
+            return False
+    raise ValueError(f"expected 'True' or 'False', got {value!r}")
+
+
+BoolStr = Annotated[bool, BeforeValidator(_parse_bool_str)]
+
+
+class DecryptedScoreData(BaseModel):
+    """Decrypted score data submitted by the osu! client.
+
+    Input is the colon-separated list produced by
+    :func:`app.api.score_sub.decrypt_score_data`. Position is load-bearing.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    beatmap_md5: str
+    username: str
+    online_checksum: str
+    n300: int
+    n100: int
+    n50: int
+    ngeki: int
+    nkatu: int
+    nmiss: int
+    score: int
+    max_combo: int
+    full_combo: BoolStr
+    grade: str
+    mods: int
+    passed: BoolStr
+    mode: int
+
+    @classmethod
+    def from_tokens(cls, tokens: list[str]) -> DecryptedScoreData:
+        if len(tokens) < 16:
+            raise ValueError(
+                f"expected at least 16 score data tokens, got {len(tokens)}",
+            )
+        return cls.model_validate(
+            {
+                "beatmap_md5": tokens[0],
+                "username": tokens[1].rstrip(),
+                "online_checksum": tokens[2],
+                "n300": tokens[3],
+                "n100": tokens[4],
+                "n50": tokens[5],
+                "ngeki": tokens[6],
+                "nkatu": tokens[7],
+                "nmiss": tokens[8],
+                "score": tokens[9],
+                "max_combo": tokens[10],
+                "full_combo": tokens[11],
+                "grade": tokens[12],
+                "mods": tokens[13],
+                "passed": tokens[14],
+                "mode": tokens[15],
+            },
+        )

--- a/app/models/score.py
+++ b/app/models/score.py
@@ -8,6 +8,7 @@ from typing import Any
 from app.constants.mode import Mode
 from app.constants.mods import Mods
 from app.constants.score_status import ScoreStatus
+from app.models.decrypted_score_data import DecryptedScoreData
 from app.models.user import User
 
 
@@ -111,29 +112,29 @@ class Score:
         )
 
     @classmethod
-    def from_submission(cls, data: list[str], map_md5: str, user: User) -> Score:
-        return Score(
+    def from_decrypted(cls, data: DecryptedScoreData, user: User) -> Score:
+        return cls(
             id=0,  # set later
-            map_md5=map_md5,
+            map_md5=data.beatmap_md5,
             user_id=user.id,
-            mode=Mode.from_lb(int(data[13]), int(data[11])),
-            mods=Mods(int(data[11])),
+            mode=Mode.from_lb(data.mode, data.mods),
+            mods=Mods(data.mods),
             pp=0.0,  # set later
             sr=0.0,  # set later
-            score=int(data[7]),
-            max_combo=int(data[8]),
+            score=data.score,
+            max_combo=data.max_combo,
             acc=0.0,  # set later
-            n300=int(data[1]),
-            n100=int(data[2]),
-            n50=int(data[3]),
-            nmiss=int(data[6]),
-            ngeki=int(data[4]),
-            nkatu=int(data[5]),
-            passed=data[12] == "True",
+            n300=data.n300,
+            n100=data.n100,
+            n50=data.n50,
+            nmiss=data.nmiss,
+            ngeki=data.ngeki,
+            nkatu=data.nkatu,
+            passed=data.passed,
             quit=False,  # set later
-            full_combo=data[9] == "True",
+            full_combo=data.full_combo,
             status=ScoreStatus.FAILED,  # set later
             time=int(time.time()),
             time_elapsed=0,  # set later
-            online_checksum=data[0],
+            online_checksum=data.online_checksum,
         )

--- a/app/usecases/score.py
+++ b/app/usecases/score.py
@@ -5,13 +5,39 @@ import hashlib
 import app.state
 import app.usecases
 from app import job_scheduling
+from app.constants.score_status import ScoreStatus
 from app.models.achievement import Achievement
 from app.models.beatmap import Beatmap
 from app.models.score import Score
 from app.models.stats import Stats
 from app.models.user import User
 from app.objects.binary import BinaryWriter
+from app.repositories.leaderboards import LeaderboardScore
 from app.utils.datetime import timestamp_to_dotnet_ticks
+
+
+def calculate_status(
+    score: Score,
+    previous_best: LeaderboardScore | None,
+) -> ScoreStatus:
+    """Determine the ``ScoreStatus`` for a freshly-submitted ``score``.
+
+    Pure function; does not mutate ``score`` or touch external state.
+    """
+    if not score.passed:
+        return ScoreStatus.QUIT if score.quit else ScoreStatus.FAILED
+
+    if previous_best is None:
+        return ScoreStatus.BEST
+
+    if score.pp > previous_best["pp"]:
+        return ScoreStatus.BEST
+
+    # spin to win: same pp, higher raw score still counts as new best
+    if score.pp == previous_best["pp"] and score.score > previous_best["score"]:
+        return ScoreStatus.BEST
+
+    return ScoreStatus.SUBMITTED
 
 
 async def unlock_achievements(score: Score, stats: Stats) -> list[Achievement]:

--- a/app/usecases/stats.py
+++ b/app/usecases/stats.py
@@ -73,6 +73,31 @@ async def get_redis_rank(user_id: int, mode: Mode) -> RankInfo:
     return RankInfo(global_rank, country_rank)
 
 
+def adjust_grade_counter(stats: Stats, grade: str, delta: int) -> None:
+    """Increment/decrement the per-grade counter on ``stats``.
+
+    ``delta`` is typically ``+1`` for a new best score or ``-1`` when the
+    previous best is being displaced. Unknown grades are ignored.
+    """
+    match grade:
+        case "XH":
+            stats.xh_count += delta
+        case "X":
+            stats.x_count += delta
+        case "SH":
+            stats.sh_count += delta
+        case "S":
+            stats.s_count += delta
+        case "A":
+            stats.a_count += delta
+        case "B":
+            stats.b_count += delta
+        case "C":
+            stats.c_count += delta
+        case "D":
+            stats.d_count += delta
+
+
 async def full_recalc(stats: Stats, score_pp: float) -> None:
     db_scores = await app.state.services.database.fetch_all(
         f"SELECT s.accuracy, s.pp FROM {stats.mode.scores_table} s "


### PR DESCRIPTION
## Summary

Week 1 of the code-quality plan. Four independent commits, each small, `mypy --strict` clean, no behavior change outside the error path.

- Stop using `assert` for control flow in `parse_form` (stripped under `python -O`)
- Parse decrypted score data via a pydantic model (`DecryptedScoreData`), removing magic-index access (`data[11]`, `data[13]`, `data[15]` …) from both `submit_score` and `Score.from_submission`
- Collapse two 8-branch grade if/elif chains in the score submission flow into a single `adjust_grade_counter(stats, grade, delta)` helper
- Re-extract `calculate_status` out of the submission handler into `usecases.score` as a pure function (USSR had this; was inlined on the fork)

No new dependencies — pydantic is already transitively installed via FastAPI.

## Commits

1. `refactor: stop using assert for parse_form control flow`
2. `refactor: parse decrypted score data via pydantic model`
3. `refactor: collapse grade counter if/elif chains`
4. `refactor: extract calculate_status as a pure function`

## Test plan

- [x] `mypy .` passes (79 files, strict config)
- [ ] Score submission end-to-end against a dev client (error paths now surface as structured log warnings instead of `AssertionError`s)
- [ ] Malformed token count → 400-style `"error: no"` with a `"Invalid decrypted score data"` log entry
- [ ] Grade counter regression: XH/X/SH/S/A/B/C/D all still increment/decrement

## Next

Week 2 adds a composition-root `AppContainer`, integration tests via `TestClient` + docker-compose, and starts migrating endpoints off `app.state.services.*`. Week 3 breaks `submit_score` into a pipeline of named stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)