### PR TITLE
week 2d: four more score-submission integration tests

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,10 +1,6 @@
 services:
   mysql:
     image: mysql:8.0
-    # Match the sql_mode the production migrations were authored under so
-    # that AUTO_INCREMENT columns (e.g. pp_limits.gamemode) can be inserted
-    # with literal 0.
-    command: ["--sql-mode=NO_AUTO_VALUE_ON_ZERO,STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"]
     environment:
       MYSQL_ROOT_PASSWORD: testroot
       MYSQL_DATABASE: score_service_test

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,6 +1,10 @@
 services:
   mysql:
     image: mysql:8.0
+    # Match the sql_mode the production migrations were authored under so
+    # that AUTO_INCREMENT columns (e.g. pp_limits.gamemode) can be inserted
+    # with literal 0.
+    command: ["--sql-mode=NO_AUTO_VALUE_ON_ZERO,STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"]
     environment:
       MYSQL_ROOT_PASSWORD: testroot
       MYSQL_DATABASE: score_service_test

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from collections.abc import Iterator
+from typing import Any
 
+import httpx
 import pytest
 import respx
 from fastapi.testclient import TestClient
@@ -10,6 +12,10 @@ from fastapi.testclient import TestClient
 import config
 from app.state.services import Database
 from app.state.services import dsn
+from tests.integration.helpers import seed_beatmap
+from tests.integration.helpers import seed_pp_limits
+from tests.integration.helpers import seed_user
+from tests.integration.helpers import seed_user_stats
 
 
 @pytest.fixture(scope="session")
@@ -93,3 +99,86 @@ def respx_mock() -> Iterator[respx.MockRouter]:
     # care about; unreferenced stubs don't fail the test.
     with respx.mock(assert_all_called=False) as mock:
         yield mock
+
+
+@pytest.fixture(autouse=True)
+async def pp_limits(db: Database) -> None:
+    # Production has pp_limits seeded; tests need it too or every score
+    # submission > 0 pp trips the pp-cap restrict guard.
+    await seed_pp_limits(db)
+
+
+@pytest.fixture
+async def user(db: Database) -> dict[str, Any]:
+    seeded = await seed_user(db)
+    await seed_user_stats(db, user_id=seeded["user_id"])
+    return seeded
+
+
+@pytest.fixture
+async def beatmap(db: Database) -> dict[str, Any]:
+    return await seed_beatmap(db)
+
+
+@pytest.fixture
+def external_service_stubs(
+    respx_mock: respx.MockRouter,
+    beatmap: dict[str, Any],
+) -> dict[str, respx.Route]:
+    """Default stubs for the three services submit_score calls into.
+
+    Tests use the returned dict to assert that a given route was or was not
+    hit (e.g. bancho fokabot-message for first-place announces / restricts).
+    """
+    beatmaps_route = respx_mock.get(
+        "http://beatmaps.test/api/akatsuki/v1/beatmaps/lookup",
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "beatmap_id": beatmap["beatmap_id"],
+                "beatmapset_id": beatmap["beatmap_id"] + 1,
+                "beatmap_md5": beatmap["beatmap_md5"],
+                "song_name": "Test Artist - Test Song [Test Diff]",
+                "file_name": "test.osu",
+                "ar": 9.0,
+                "od": 9.0,
+                "mode": 0,
+                "max_combo": 1000,
+                "hit_length": 120,
+                "bpm": 180,
+                "ranked": 2,
+                "latest_update": 0,
+                "ranked_status_freezed": 0,
+                "playcount": 0,
+                "passcount": 0,
+                "rating": 10.0,
+                "rankedby": None,
+                "bancho_ranked_status": None,
+                "count_circles": 500,
+                "count_sliders": 500,
+                "count_spinners": 0,
+            },
+        ),
+    )
+    performance_route = respx_mock.post(
+        "http://performance.test/api/v1/calculate",
+    ).mock(
+        return_value=httpx.Response(200, json=[{"pp": 123.4, "stars": 6.5}]),
+    )
+    match_details_route = respx_mock.get(
+        "http://bancho.test/api/v1/playerMatchDetails",
+    ).mock(
+        return_value=httpx.Response(200, json={"message": "no match"}),
+    )
+    fokabot_route = respx_mock.get(
+        "http://bancho.test/api/v1/fokabotMessage",
+    ).mock(
+        return_value=httpx.Response(200),
+    )
+    return {
+        "beatmaps": beatmaps_route,
+        "performance": performance_route,
+        "match_details": match_details_route,
+        "fokabot": fokabot_route,
+    }

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -6,10 +6,15 @@ from base64 import b64encode
 from typing import Any
 
 import bcrypt
+import httpx
+from fastapi.testclient import TestClient
 from py3rijndael import Pkcs7Padding
 from py3rijndael import RijndaelCbc
 
 from app.state.services import Database
+
+SUBMIT_SCORE_PATH = "/web/osu-submit-modular-selector.php"
+DEFAULT_OSU_VERSION = "20210103"
 
 
 def hash_password(plaintext: str) -> tuple[str, str]:
@@ -98,6 +103,33 @@ async def seed_user(
     }
 
 
+async def seed_pp_limits(
+    db: Database,
+    *,
+    pp_cap: int = 30_000,
+) -> None:
+    """Populate pp_limits with a high cap for every vanilla game mode.
+
+    Without a row, app.usecases.pp_cap.get_pp_cap returns 0, which makes every
+    non-whitelisted score submission above 0 pp trip the pp-cap restrict
+    path. Production seeds real values; tests use a cap big enough that no
+    default test submission hits it, unless a test overrides to something
+    lower.
+    """
+    for mode in (0, 1, 2, 3):
+        await db.execute(
+            """
+            INSERT INTO pp_limits (
+                gamemode, pp, relax_pp, flashlight_pp,
+                relax_flashlight_pp, autopilot_pp, autopilot_flashlight_pp
+            ) VALUES (
+                :gamemode, :cap, :cap, :cap, :cap, :cap, :cap
+            )
+            """,
+            {"gamemode": mode, "cap": pp_cap},
+        )
+
+
 async def seed_user_stats(
     db: Database,
     *,
@@ -109,6 +141,91 @@ async def seed_user_stats(
     await db.execute(
         "INSERT INTO user_stats (user_id, mode) VALUES (:user_id, :mode)",
         {"user_id": user_id, "mode": mode},
+    )
+
+
+def build_score_tokens(
+    *,
+    beatmap_md5: str,
+    username: str,
+    online_checksum: str = "c" * 32,
+    n300: int = 100,
+    n100: int = 2,
+    n50: int = 1,
+    ngeki: int = 0,
+    nkatu: int = 0,
+    nmiss: int = 0,
+    score: int = 123_456,
+    max_combo: int = 500,
+    full_combo: str = "True",
+    grade: str = "S",
+    mods: int = 0,
+    passed: str = "True",
+    mode: int = 0,
+) -> list[str]:
+    """Build the 16-token score payload in the positional shape the
+    osu! client serializes before encrypting."""
+    return [
+        beatmap_md5,
+        username,
+        online_checksum,
+        str(n300),
+        str(n100),
+        str(n50),
+        str(ngeki),
+        str(nkatu),
+        str(nmiss),
+        str(score),
+        str(max_combo),
+        full_combo,
+        grade,
+        str(mods),
+        passed,
+        str(mode),
+    ]
+
+
+def submit_score_request(
+    client: TestClient,
+    *,
+    password_md5: str,
+    score_tokens: list[str],
+    user_agent: str = "osu!",
+    osu_version: str = DEFAULT_OSU_VERSION,
+    client_hash: str | None = None,
+    replay_bytes: bytes = DUMMY_REPLAY_BYTES,
+) -> httpx.Response:
+    """Encrypt the tokens and POST the submit-modular-selector multipart.
+
+    Mirrors what the osu! client sends: score and client-hash are encrypted
+    with the same IV; the `score` multipart key has two parts — the
+    encrypted score string and the replay file upload.
+    """
+    score_data_b64, iv_b64, client_hash_b64 = encrypt_score_payload(
+        score_tokens=score_tokens,
+        client_hash=client_hash or ":".join(["0" * 32] * 5),
+        osu_version=osu_version,
+    )
+    return client.post(
+        SUBMIT_SCORE_PATH,
+        headers={"user-agent": user_agent},
+        data={
+            "x": "0",
+            "ft": "0",
+            "fs": b64encode(b"visual-settings").decode(),
+            "bmk": score_tokens[0],
+            "sbk": "",
+            "iv": iv_b64.decode(),
+            "c1": "abc-unique-id",
+            "st": "0",
+            "pass": password_md5,
+            "osuver": osu_version,
+            "s": client_hash_b64.decode(),
+        },
+        files=[
+            ("score", (None, score_data_b64, "text/plain")),
+            ("score", ("replay.osr", replay_bytes, "application/octet-stream")),
+        ],
     )
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -115,19 +115,27 @@ async def seed_pp_limits(
     path. Production seeds real values; tests use a cap big enough that no
     default test submission hits it, unless a test overrides to something
     lower.
+
+    pp_limits.gamemode is an AUTO_INCREMENT column, so inserting literal 0
+    requires ``NO_AUTO_VALUE_ON_ZERO`` in sql_mode. We set it on a single
+    held connection for the duration of the inserts rather than relying on
+    the server default — server sql_mode is an infra concern we don't want
+    tests to assume.
     """
-    for mode in (0, 1, 2, 3):
-        await db.execute(
-            """
-            INSERT INTO pp_limits (
-                gamemode, pp, relax_pp, flashlight_pp,
-                relax_flashlight_pp, autopilot_pp, autopilot_flashlight_pp
-            ) VALUES (
-                :gamemode, :cap, :cap, :cap, :cap, :cap, :cap
+    async with db.write_database.connection() as conn:
+        await conn.execute("SET SESSION sql_mode = 'NO_AUTO_VALUE_ON_ZERO'")
+        for mode in (0, 1, 2, 3):
+            await conn.execute(
+                """
+                INSERT INTO pp_limits (
+                    gamemode, pp, relax_pp, flashlight_pp,
+                    relax_flashlight_pp, autopilot_pp, autopilot_flashlight_pp
+                ) VALUES (
+                    :gamemode, :cap, :cap, :cap, :cap, :cap, :cap
+                )
+                """,
+                {"gamemode": mode, "cap": pp_cap},
             )
-            """,
-            {"gamemode": mode, "cap": pp_cap},
-        )
 
 
 async def seed_user_stats(

--- a/tests/integration/test_submit_score.py
+++ b/tests/integration/test_submit_score.py
@@ -1,130 +1,30 @@
 from __future__ import annotations
 
-from base64 import b64encode
+from typing import Any
 
-import httpx
 import pytest
 import respx
 from fastapi.testclient import TestClient
 
 from app.state.services import Database
-from tests.integration.helpers import DUMMY_REPLAY_BYTES
-from tests.integration.helpers import encrypt_score_payload
-from tests.integration.helpers import seed_beatmap
-from tests.integration.helpers import seed_user
-from tests.integration.helpers import seed_user_stats
-
-OSU_VERSION = "20210103"
+from tests.integration.helpers import build_score_tokens
+from tests.integration.helpers import submit_score_request
 
 
 async def test_happy_path_score_submission(
     client: TestClient,
     db: Database,
-    respx_mock: respx.MockRouter,
+    user: dict[str, Any],
+    beatmap: dict[str, Any],
+    external_service_stubs: dict[str, respx.Route],
 ) -> None:
-    user = await seed_user(db)
-    await seed_user_stats(db, user_id=user["user_id"])
-    beatmap = await seed_beatmap(db)
-
-    # Beatmaps service: the app looks up the beatmap by md5 over HTTP.
-    respx_mock.get(
-        "http://beatmaps.test/api/akatsuki/v1/beatmaps/lookup",
-    ).mock(
-        return_value=httpx.Response(
-            200,
-            json={
-                "beatmap_id": beatmap["beatmap_id"],
-                "beatmapset_id": beatmap["beatmap_id"] + 1,
-                "beatmap_md5": beatmap["beatmap_md5"],
-                "song_name": "Test Artist - Test Song [Test Diff]",
-                "file_name": "test.osu",
-                "ar": 9.0,
-                "od": 9.0,
-                "mode": 0,
-                "max_combo": 1000,
-                "hit_length": 120,
-                "bpm": 180,
-                "ranked": 2,
-                "latest_update": 0,
-                "ranked_status_freezed": 0,
-                "playcount": 0,
-                "passcount": 0,
-                "rating": 10.0,
-                "rankedby": None,
-                "bancho_ranked_status": None,
-                "count_circles": 500,
-                "count_sliders": 500,
-                "count_spinners": 0,
-            },
+    response = submit_score_request(
+        client,
+        password_md5=user["password_md5"],
+        score_tokens=build_score_tokens(
+            beatmap_md5=beatmap["beatmap_md5"],
+            username=user["username"],
         ),
-    )
-
-    # Performance service: return fixed pp/stars so the test stays deterministic.
-    respx_mock.post("http://performance.test/api/v1/calculate").mock(
-        return_value=httpx.Response(200, json=[{"pp": 123.4, "stars": 6.5}]),
-    )
-
-    # Bancho service: no multiplayer match for this user, and first-place chat
-    # announce is swallowed as a 200.
-    respx_mock.get("http://bancho.test/api/v1/playerMatchDetails").mock(
-        return_value=httpx.Response(200, json={"message": "no match"}),
-    )
-    respx_mock.get("http://bancho.test/api/v1/fokabotMessage").mock(
-        return_value=httpx.Response(200),
-    )
-
-    # Build the 16-token score payload in the exact positional shape the
-    # osu! client serializes.
-    score_tokens = [
-        beatmap["beatmap_md5"],
-        user["username"],
-        "a" * 32,  # online checksum
-        "100",  # n300
-        "2",  # n100
-        "1",  # n50
-        "0",  # ngeki
-        "0",  # nkatu
-        "0",  # nmiss
-        "123456",  # score
-        "500",  # max_combo
-        "True",  # full_combo
-        "S",  # grade
-        "0",  # mods
-        "True",  # passed
-        "0",  # mode
-    ]
-    score_data_b64, iv_b64, client_hash_b64 = encrypt_score_payload(
-        score_tokens=score_tokens,
-        client_hash=":".join(["0" * 32] * 5),
-        osu_version=OSU_VERSION,
-    )
-
-    response = client.post(
-        "/web/osu-submit-modular-selector.php",
-        headers={"user-agent": "osu!"},
-        data={
-            "x": "0",
-            "ft": "0",
-            "fs": b64encode(b"visual-settings").decode(),
-            "bmk": beatmap["beatmap_md5"],
-            "sbk": "",
-            "iv": iv_b64.decode(),
-            "c1": "abc-unique-id",
-            "st": "0",
-            "pass": user["password_md5"],
-            "osuver": OSU_VERSION,
-            "s": client_hash_b64.decode(),
-        },
-        files=[
-            # A plain form value (filename=None) under the key "score".
-            ("score", (None, score_data_b64, "text/plain")),
-            # And a file upload under the same key, matching what the
-            # osu! client uploads as the replay.
-            (
-                "score",
-                ("replay.osr", DUMMY_REPLAY_BYTES, "application/octet-stream"),
-            ),
-        ],
     )
 
     assert response.status_code == 200
@@ -133,22 +33,170 @@ async def test_happy_path_score_submission(
     assert b"chartId:overall" in body, body
     assert b"onlineScoreId:" in body, body
 
-    # The score was persisted with the expected raw score value.
     score_row = await db.fetch_one(
         "SELECT score, pp, play_mode, completed FROM scores WHERE userid = :uid",
         {"uid": user["user_id"]},
     )
     assert score_row is not None
-    assert score_row["score"] == 123456
+    assert score_row["score"] == 123_456
     assert score_row["pp"] == pytest.approx(123.4, abs=1e-3)
     assert score_row["play_mode"] == 0
     assert score_row["completed"] == 3  # ScoreStatus.BEST
 
-    # Stats were bumped.
     stats_row = await db.fetch_one(
         "SELECT playcount, total_score FROM user_stats WHERE user_id = :uid AND mode = 0",
         {"uid": user["user_id"]},
     )
     assert stats_row is not None
     assert stats_row["playcount"] == 1
-    assert stats_row["total_score"] == 123456
+    assert stats_row["total_score"] == 123_456
+
+
+async def test_duplicate_checksum_rejected(
+    client: TestClient,
+    db: Database,
+    user: dict[str, Any],
+    beatmap: dict[str, Any],
+    external_service_stubs: dict[str, respx.Route],
+) -> None:
+    # Seed a score that already owns the online_checksum the submission will
+    # use; the handler's uniqueness guard should reject the second attempt.
+    duplicate_checksum = "c" * 32
+    await db.execute(
+        """
+        INSERT INTO scores (
+            beatmap_md5, userid, score, play_mode, completed, checksum
+        ) VALUES (
+            :md5, :uid, :score, 0, 3, :checksum
+        )
+        """,
+        {
+            "md5": beatmap["beatmap_md5"],
+            "uid": user["user_id"],
+            "score": 50_000,
+            "checksum": duplicate_checksum,
+        },
+    )
+
+    response = submit_score_request(
+        client,
+        password_md5=user["password_md5"],
+        score_tokens=build_score_tokens(
+            beatmap_md5=beatmap["beatmap_md5"],
+            username=user["username"],
+            online_checksum=duplicate_checksum,
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.content == b"error: no"
+
+    # The pre-existing row is still the only one.
+    count = await db.fetch_val(
+        "SELECT COUNT(*) FROM scores WHERE userid = :uid",
+        {"uid": user["user_id"]},
+    )
+    assert count == 1
+
+
+async def test_failed_score_records_failed_status(
+    client: TestClient,
+    db: Database,
+    user: dict[str, Any],
+    beatmap: dict[str, Any],
+    external_service_stubs: dict[str, respx.Route],
+) -> None:
+    response = submit_score_request(
+        client,
+        password_md5=user["password_md5"],
+        score_tokens=build_score_tokens(
+            beatmap_md5=beatmap["beatmap_md5"],
+            username=user["username"],
+            passed="False",
+        ),
+    )
+
+    assert response.status_code == 200
+
+    score_row = await db.fetch_one(
+        "SELECT completed FROM scores WHERE userid = :uid",
+        {"uid": user["user_id"]},
+    )
+    assert score_row is not None
+    assert score_row["completed"] == 1  # ScoreStatus.FAILED
+
+    # Ranked score is only bumped for passed BEST scores on ranked maps.
+    stats_row = await db.fetch_one(
+        "SELECT ranked_score, playcount FROM user_stats WHERE user_id = :uid AND mode = 0",
+        {"uid": user["user_id"]},
+    )
+    assert stats_row is not None
+    assert stats_row["ranked_score"] == 0
+    # Playcount still bumps on any submission.
+    assert stats_row["playcount"] == 1
+
+
+async def test_bad_user_agent_restricts_user(
+    client: TestClient,
+    db: Database,
+    user: dict[str, Any],
+    beatmap: dict[str, Any],
+    external_service_stubs: dict[str, respx.Route],
+) -> None:
+    # user.privileges starts at 3 (USER_NORMAL | USER_PUBLIC); after restrict
+    # the USER_PUBLIC bit (1) is cleared, leaving 2.
+    response = submit_score_request(
+        client,
+        password_md5=user["password_md5"],
+        score_tokens=build_score_tokens(
+            beatmap_md5=beatmap["beatmap_md5"],
+            username=user["username"],
+        ),
+        user_agent="python-httpx/0.0.0",
+    )
+
+    assert response.status_code == 200
+
+    updated = await db.fetch_one(
+        "SELECT privileges, ban_datetime FROM users WHERE id = :uid",
+        {"uid": user["user_id"]},
+    )
+    assert updated is not None
+    assert updated["privileges"] & 1 == 0, "USER_PUBLIC bit should be cleared"
+    assert updated["ban_datetime"] != 0
+
+
+async def test_first_place_inserts_scores_first_row(
+    client: TestClient,
+    db: Database,
+    user: dict[str, Any],
+    beatmap: dict[str, Any],
+    external_service_stubs: dict[str, respx.Route],
+) -> None:
+    # With no prior scores on the map, the submitted score becomes #1 and
+    # the handler writes to scores_first. The chat announce is scheduled as
+    # a background job; we don't assert on it here because it runs outside
+    # the request lifecycle.
+    response = submit_score_request(
+        client,
+        password_md5=user["password_md5"],
+        score_tokens=build_score_tokens(
+            beatmap_md5=beatmap["beatmap_md5"],
+            username=user["username"],
+        ),
+    )
+
+    assert response.status_code == 200
+
+    first_row = await db.fetch_one(
+        """
+        SELECT userid, scoreid, mode, rx
+          FROM scores_first
+         WHERE beatmap_md5 = :md5
+        """,
+        {"md5": beatmap["beatmap_md5"]},
+    )
+    assert first_row is not None
+    assert first_row["userid"] == user["user_id"]
+    assert first_row["mode"] == 0
+    assert first_row["rx"] == 0


### PR DESCRIPTION
## Summary

Completes the planned integration-test quartet for score submission, covering the branches of ``submit_score`` that genuinely need real DB + HTTP.

### New tests

- **test_duplicate_checksum_rejected** — pre-seed a score with the same ``online_checksum``; handler returns ``b"error: no"``, no new row.
- **test_failed_score_records_failed_status** — ``passed="False"`` token → row with ``completed = ScoreStatus.FAILED``; playcount bumps, ``ranked_score`` doesn't.
- **test_bad_user_agent_restricts_user** — user-agent != ``"osu!"`` clears the ``USER_PUBLIC`` privilege bit and sets ``ban_datetime``.
- **test_first_place_inserts_scores_first_row** — no prior scores on the map → ``handle_first_place`` writes to ``scores_first``. Chat announce is a background job so it's not asserted here.

### Harness / support changes

- Extract ``submit_score_request`` + ``build_score_tokens`` helpers. Each test is now ~20 lines instead of ~80 of multipart construction.
- Hoist ``user`` / ``beatmap`` / ``external_service_stubs`` up into ``conftest`` fixtures.
- Add ``seed_pp_limits`` + an autouse ``pp_limits`` fixture — without a row, ``get_pp_cap`` returns 0 and every non-whitelisted score trips the pp-cap restrict guard. That's why first-place wouldn't fire in an earlier draft of the test: the user was already being pre-restricted by pp-cap before first-place was checked. Matches production, which seeds real caps.
- ``docker-compose.test.yml``: set ``sql_mode=NO_AUTO_VALUE_ON_ZERO,STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION`` so the pp_limits seed can insert ``gamemode=0`` without MySQL silently replacing the 0 via AUTO_INCREMENT. Matches the ``sql_mode`` the production migrations were authored under.

### Still deferred

- Achievements (needs startup-cache reload machinery, its own PR).
- ScoreV2 / unrankable mods — unit-testable after week 3's handler refactor.
- Short-replay restrict, conflicting mods restrict — same.

## Test plan

- [x] ``make utest`` — 31 pass
- [x] ``make itest`` — 7 pass (2 smoke + 5 submission)
- [x] ``mypy .`` clean
- [x] ``pre-commit run --all-files`` clean
- [ ] CI both jobs green

## Next

Week 3: break ``submit_score`` into named pipeline stages so the remaining branches become unit-testable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)