### PR TITLE
chore: silence app-side deprecation warnings

### DIFF
--- a/app/init_api.py
+++ b/app/init_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+from collections.abc import AsyncIterator
 
 import aio_pika
 import aiobotocore.session
@@ -25,100 +26,96 @@ from app.state.context import AppContext
 ctx_stack = contextlib.AsyncExitStack()
 
 
-def init_events(asgi_app: FastAPI) -> None:
-    @asgi_app.on_event("startup")
-    async def on_startup() -> None:
-        await app.state.services.database.connect()
+@contextlib.asynccontextmanager
+async def lifespan(asgi_app: FastAPI) -> AsyncIterator[None]:
+    await app.state.services.database.connect()
 
-        # explicitly providing username & password as non None will call the AUTH cmd
-        # which will fail if a password is not set.
-        # if they're not using the default user then it should explicitly auth as that user
-        # however it will fail if they have no password set
-        # but this is still better than implicitly working as the default one
-        should_send_redis_authentication = (
-            config.REDIS_PASS != "" or config.REDIS_USER != "default"
-        )
-        app.state.services.redis = aioredis.Redis(
-            host=config.REDIS_HOST,
-            port=config.REDIS_PORT,
-            db=config.REDIS_DB,
-            username=config.REDIS_USER if should_send_redis_authentication else None,
-            password=config.REDIS_PASS if should_send_redis_authentication else None,
-            ssl=config.REDIS_USE_SSL,
-        )
-        await app.state.services.redis.initialize()  # type: ignore[unused-awaitable]
-        await app.state.services.redis.ping()  # type: ignore[misc]
+    # explicitly providing username & password as non None will call the AUTH cmd
+    # which will fail if a password is not set.
+    # if they're not using the default user then it should explicitly auth as that user
+    # however it will fail if they have no password set
+    # but this is still better than implicitly working as the default one
+    should_send_redis_authentication = (
+        config.REDIS_PASS != "" or config.REDIS_USER != "default"
+    )
+    app.state.services.redis = aioredis.Redis(
+        host=config.REDIS_HOST,
+        port=config.REDIS_PORT,
+        db=config.REDIS_DB,
+        username=config.REDIS_USER if should_send_redis_authentication else None,
+        password=config.REDIS_PASS if should_send_redis_authentication else None,
+        ssl=config.REDIS_USE_SSL,
+    )
+    await app.state.services.redis.initialize()  # type: ignore[unused-awaitable]
+    await app.state.services.redis.ping()  # type: ignore[misc]
 
-        app.state.services.http_client = httpx.AsyncClient()
+    app.state.services.http_client = httpx.AsyncClient()
 
-        app.state.services.s3_client = None
-        if (
-            config.AWS_ENDPOINT_URL
-            and config.AWS_REGION
-            and config.AWS_ACCESS_KEY_ID
-            and config.AWS_SECRET_ACCESS_KEY
-        ):
-            app.state.services.s3_client = await ctx_stack.enter_async_context(
-                aiobotocore.session.get_session().create_client(
-                    service_name="s3",
-                    region_name=config.AWS_REGION,
-                    aws_access_key_id=config.AWS_ACCESS_KEY_ID,
-                    aws_secret_access_key=config.AWS_SECRET_ACCESS_KEY,
-                    endpoint_url=config.AWS_ENDPOINT_URL,
-                ),
-            )
-
-        app.state.services.amqp = None
-        app.state.services.amqp_channel = None
-        if (
-            config.AMQP_USER
-            and config.AMQP_PASS
-            and config.AMQP_HOST
-            and config.AMQP_PORT
-        ):
-            app.state.services.amqp = await aio_pika.connect_robust(
-                f"amqp://{config.AMQP_USER}:{config.AMQP_PASS}@{config.AMQP_HOST}:{config.AMQP_PORT}/",
-            )
-
-            app.state.services.amqp_channel = await app.state.services.amqp.channel()
-
-        await app.state.cache.init_cache()
-
-        # All services are populated on app.state.services at this point.
-        # Expose them as a typed context for `Depends(get_context)` users.
-        # The module-level globals on app.state.services are kept in sync as a
-        # backwards-compatibility shim during the gradual migration.
-        asgi_app.state.context = AppContext(
-            database=app.state.services.database,
-            redis=app.state.services.redis,
-            http_client=app.state.services.http_client,
-            amqp=app.state.services.amqp,
-            amqp_channel=app.state.services.amqp_channel,
-            s3_client=app.state.services.s3_client,
+    app.state.services.s3_client = None
+    if (
+        config.AWS_ENDPOINT_URL
+        and config.AWS_REGION
+        and config.AWS_ACCESS_KEY_ID
+        and config.AWS_SECRET_ACCESS_KEY
+    ):
+        app.state.services.s3_client = await ctx_stack.enter_async_context(
+            aiobotocore.session.get_session().create_client(
+                service_name="s3",
+                region_name=config.AWS_REGION,
+                aws_access_key_id=config.AWS_ACCESS_KEY_ID,
+                aws_secret_access_key=config.AWS_SECRET_ACCESS_KEY,
+                endpoint_url=config.AWS_ENDPOINT_URL,
+            ),
         )
 
-        logging.info("Server has started!")
+    app.state.services.amqp = None
+    app.state.services.amqp_channel = None
+    if config.AMQP_USER and config.AMQP_PASS and config.AMQP_HOST and config.AMQP_PORT:
+        app.state.services.amqp = await aio_pika.connect_robust(
+            f"amqp://{config.AMQP_USER}:{config.AMQP_PASS}@{config.AMQP_HOST}:{config.AMQP_PORT}/",
+        )
 
-    @asgi_app.on_event("shutdown")
-    async def on_shutdown() -> None:
-        await job_scheduling.await_running_jobs(timeout=7.5)
+        app.state.services.amqp_channel = await app.state.services.amqp.channel()
 
-        await app.state.services.database.disconnect()
+    await app.state.cache.init_cache()
 
-        await app.state.services.redis.close()
+    # All services are populated on app.state.services at this point.
+    # Expose them as a typed context for `Depends(get_context)` users.
+    # The module-level globals on app.state.services are kept in sync as a
+    # backwards-compatibility shim during the gradual migration.
+    asgi_app.state.context = AppContext(
+        database=app.state.services.database,
+        redis=app.state.services.redis,
+        http_client=app.state.services.http_client,
+        amqp=app.state.services.amqp,
+        amqp_channel=app.state.services.amqp_channel,
+        s3_client=app.state.services.s3_client,
+    )
 
-        await app.state.services.http_client.aclose()
+    logging.info("Server has started!")
 
-        if app.state.services.amqp_channel is not None:
-            await app.state.services.amqp_channel.close()
+    yield
 
-        if app.state.services.amqp is not None:
-            await app.state.services.amqp.close()
+    await job_scheduling.await_running_jobs(timeout=7.5)
 
-        await ctx_stack.aclose()
+    await app.state.services.database.disconnect()
 
-        logging.info("Server has shutdown!")
+    await app.state.services.redis.aclose()
 
+    await app.state.services.http_client.aclose()
+
+    if app.state.services.amqp_channel is not None:
+        await app.state.services.amqp_channel.close()
+
+    if app.state.services.amqp is not None:
+        await app.state.services.amqp.close()
+
+    await ctx_stack.aclose()
+
+    logging.info("Server has shutdown!")
+
+
+def init_middleware(asgi_app: FastAPI) -> None:
     @asgi_app.middleware("http")
     async def http_middleware(
         request: Request,
@@ -149,9 +146,9 @@ def init_events(asgi_app: FastAPI) -> None:
 
 
 def init_fastapi() -> FastAPI:
-    asgi_app = FastAPI()
+    asgi_app = FastAPI(lifespan=lifespan)
 
-    init_events(asgi_app)
+    init_middleware(asgi_app)
 
     import app.api
 

--- a/config.py
+++ b/config.py
@@ -5,7 +5,11 @@ import logging
 from starlette.config import Config
 from starlette.datastructures import CommaSeparatedStrings
 
-config = Config(".env")
+# Config reads from os.environ. Prod's .env is sourced into the shell by
+# scripts/bootstrap.sh, tests load .env.test via python-dotenv — nothing
+# relies on starlette's own .env lookup, which was only emitting a "Config
+# file '.env' not found" warning on every import.
+config = Config()
 
 APP_HOST = config("APP_HOST")
 APP_PORT = config("APP_PORT", cast=int)


### PR DESCRIPTION
## Summary

Three pre-existing deprecation warnings were firing on every test run and service boot. Knocked out without any behavior change.

- **\`@asgi_app.on_event(\"startup\"/\"shutdown\")\` → lifespan context manager.** FastAPI has deprecated the event decorators in favor of a single async context manager passed to \`FastAPI(lifespan=...)\`. Moves the two functions in \`init_api.py\` into one with a \`yield\` between. Also splits the unrelated middleware/exception-handler registration into its own \`init_middleware\`, since it has nothing to do with startup/shutdown.
- **\`aioredis.Redis.close()\` → \`aclose()\`.** redis-py deprecated \`close()\` in 5.0.1 because the method isn't idempotent on closed connections.
- **\`starlette.config.Config(\".env\")\` → \`Config()\`.** Nothing in the app relied on starlette loading \`.env\` for us — prod sources \`.env\` via \`scripts/bootstrap.sh\`, tests load \`.env.test\` via \`python-dotenv\`. The \`\".env\"\` argument only produced a \`UserWarning: Config file '.env' not found\` on every import.

## What's left

- **\`ORJSONResponse\` deprecation** — fires from FastAPI internals during routing setup. Chasing it means auditing every endpoint's response path and is FastAPI-version-dependent. Best paired with a future FastAPI bump.
- **Node.js 20 actions / MySQL CLI password** — external / cosmetic.

Warnings dropped from 8 → 2 on integration runs; down to the single FastAPI one on unit runs.

## Test plan

- [x] \`make utest\` — 31 pass
- [x] \`make itest\` — 7 pass
- [x] \`mypy .\` clean
- [x] \`pre-commit run --all-files\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)